### PR TITLE
Threadsafe wrappers for KATCPResource

### DIFF
--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -8,6 +8,7 @@ import logging
 import tornado
 
 from tornado.gen import Return
+
 from katcp import Message, Sensor
 from katcp.core import hashable_identity
 from katcp.sampling import SampleStrategy
@@ -610,4 +611,3 @@ class KATCPReply(_KATCPReplyTuple):
     def succeeded(self):
         """True if request succeeded (i.e. first reply argument is 'ok')."""
         return bool(self)
-

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -984,6 +984,7 @@ class DeviceTestServer(DeviceServer):
         self._check_cnt_futures()
         return super(DeviceTestServer, self).handle_message(req, msg)
 
+    @property
     def messages(self):
         return self.__msgs
 

--- a/scratchpad/tornado/drive_resource_client.py
+++ b/scratchpad/tornado/drive_resource_client.py
@@ -50,8 +50,8 @@ def setup_inspecting_client():
     except Exception:
         log.exception('whups')
 
-ioloop.add_callback(setup_inspecting_client)
-#ioloop.add_callback(setup_resource_client)
+#ioloop.add_callback(setup_inspecting_client)
+ioloop.add_callback(setup_resource_client)
 
 stop = threading.Event()
 
@@ -69,6 +69,10 @@ def doreq(req, *args, **kwargs):
 
 def run_ipy():
     try:
+        iotw = resource_client.IOLoopThreadWrapper(ioloop)
+        time.sleep(0.24)
+        s = rc.sensor.an_int
+        ws = resource_client.ThreadsafeKATCPSensorWrapper(s, iotw)
         IPython.embed()
         # stop.wait(10000)
     finally:


### PR DESCRIPTION
The purpose of these wrappers is to allow the straight forward use of
KATCPResource objects by simple synchronous scripts that run on the
main thread. Performance is not a priority, since observation scripts
typically have a very low rate of interaction with the telescope.

Based on ProxyTypes (peak.utils.proxies). The original KATCPResource
objects (request, sensor, container and client types) are wrapped with
proxies that run all callables on the ioloop, blocking the calling
thread using concurrent.future.Future objects.
