### PR TITLE
Add option to daemonize ioloop_manager thread

### DIFF
--- a/katcp/client.py
+++ b/katcp/client.py
@@ -722,8 +722,8 @@ class DeviceClient(object):
         """Set the tornado.ioloop.IOLoop instance to use.
 
         This defaults to IOLoop.current(). If set_ioloop() is never called the
-        IOLoop is started in a new thread, and will be stopped if self.stop()
-        is called.
+        IOLoop is managed: started in a new thread, and will be stopped if
+        self.stop() is called.
 
         Notes
         -----
@@ -1488,6 +1488,13 @@ class CallbackClient(AsyncClient):
                                              auto_reconnect=auto_reconnect)
         self.enable_thread_safety()
 
+    def setDaemon(self, daemonic):
+        """Set daemonic state of the managed ioloop thread to True / False
+
+        Calling this method for a non-managed ioloop has no effect. Must be called before
+        start(), or it will also have no effect
+        """
+        self._ioloop_manager.setDaemon(daemonic)
 
 class BlockingClient(CallbackClient):
     pass

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -210,7 +210,7 @@ class KATCPClientResource(resource.KATCPResource):
               will be treated equivalently.
           controlled : bool, default: False
               True if control over the device (i.e. KATCP requests) is to be exposed.
-          auto_reconnect : bool
+          auto_reconnect : bool, default: True
               If True, auto-reconnect should the network connection be closed.
           auto_reconnect_delay : float seconds. Default : 0.5s
               Delay between reconnection retries.
@@ -714,8 +714,6 @@ class IOLoopThreadWrapper(object):
 
     def decorate_callable(self, callable_, timeout=None):
         """Decorate a callable to use call_in_ioloop"""
-        timeout = timeout or self.default_timeout
-
         @wraps(callable_)
         def decorated(*args, **kwargs):
             return self.call_in_ioloop(callable_, args, kwargs, timeout)

--- a/katcp/server.py
+++ b/katcp/server.py
@@ -332,6 +332,14 @@ class KATCPServer(object):
         """The (host, port) where the server is listening for connections."""
         return self._bindaddr
 
+    def setDaemon(self, daemonic):
+        """Set daemonic state of the managed ioloop thread to True / False
+
+        Calling this method for a non-managed ioloop has no effect. Must be called before
+        start(), or it will also have no effect
+        """
+        self._ioloop_manager.setDaemon(daemonic)
+
     def set_ioloop(self, ioloop=None):
         """Set the tornado IOLoop to use.
 
@@ -934,6 +942,15 @@ class DeviceServerBase(object):
     @property
     def bind_address(self):
         return self._server.bind_address
+
+    def setDaemon(self, daemonic):
+        """Set daemonic state of the managed ioloop thread to True / False
+
+        Calling this method for a non-managed ioloop has no effect. Must be called before
+        start(), or it will also have no effect
+        """
+        self._server.setDaemon(daemonic)
+
 
     def create_log_inform(self, level_name, msg, name, timestamp=None):
         """Create a katcp logging inform message.


### PR DESCRIPTION
Useful, since recent versions of Python don't run atexit handlers
before all non-daemon threads have stopped. This means you can't use
atexit for automatic thread-stopping in interactive use unless your ioloop thread is daemonic.

See Alex Martelli's answer (and comment by Neilen Marais)
http://stackoverflow.com/questions/2564137/python-how-to-terminate-a-thread-when-main-program-ends

and answer to
http://stackoverflow.com/questions/3713360/python-2-6-x-theading-signals-atexit-fail-on-some-versions