### PR TITLE
Fake resource support

### DIFF
--- a/katcp/core.py
+++ b/katcp/core.py
@@ -351,6 +351,7 @@ class Message(object):
         -----------------
         mid : str or None
             Message ID to use or None (default) for no Message ID
+
         """
         mid = kwargs.pop('mid', None)
         if len(kwargs) > 0:
@@ -367,6 +368,11 @@ class Message(object):
             The name of the message.
         args : list of strings
             The message arguments.
+
+        Keyword Arguments
+        -----------------
+        mid : str or None
+            Message ID to use or None (default) for no Message ID
 
         """
         mid = kwargs.pop('mid', None)

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -1,5 +1,7 @@
 # Copyright 2015 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
+
+
 import tornado.concurrent
 
 from thread import get_ident as get_thread_ident
@@ -7,49 +9,124 @@ from thread import get_ident as get_thread_ident
 from tornado.gen import Return
 from tornado.concurrent import Future
 
-from katcp import client, server, kattypes
+from katcp import client, server, kattypes, resource, Sensor
 from katcp.core import AttrDict, ProtocolFlags, Message, convert_method_name
 
-def get_fake_inspecting_client_instance(InspectingClass, host, port, *args, **kwargs):
-    # Note, that this mechanism makes many assumptions about the internals of
-    # InspectingClientAsync and DeviceClient, so it may well break if substantial changes
-    # are made to the implementation of either
-    class FakeInspectingClass(InspectingClass):
-        def get_inform_hook_client(self, host, port, *args, **kwargs):
-            fac = FakeAsyncClient(host, port, *args, **kwargs)
-            # We'll be ignoring the inform hooks, rather stimulating the InspectingClass at a
-            # higher level
-            fac.hook_inform = lambda *x, **xx : None
-            return fac
+def fake_KATCP_client_resource_factory(
+        KATCPClientResourceClass, fake_options, resource_spec, *args, **kwargs):
+    """Create a fake KATCPClientResource-like class and a fake-manager
 
-    ic = FakeInspectingClass(host, port, *args, **kwargs)
+    Parameters
+    ----------
+    KATCPClientResourceClass : class
+        Subclass of :class:`katcp.resource_client.KATCPClientResource`
+    fake_options : dict
+        Options for the faking process. Keys:
+            allow_any_request : bool, default False
+            (TODO not implemented behaves as if it were True)
+    resource_spec, *args, **kwargs : passed to KATCPClientResourceClass
 
-    return ic
+    A subclass of the passed-in KATCPClientResourceClass is created that replaces the
+    internal InspecingClient instances with fakes using fake_inspecting_client_factory()
+    based on the InspectingClient class used by KATCPClientResourceClass.
 
-class FakeInspectingClientManager(object):
-    def __init__(self, fake_inspecting_client):
-        self._fic = fake_inspecting_client
-        self._fkc = fake_inspecting_client.katcp_client
-        self._fkc.request_handlers['sensor-list'] = self.request_sensor_list
-        self._sensor_infos = {}
+    Returns
+    -------
+    (fake_katcp_client_resource, fake_katcp_client_resource_manager):
 
-    @kattypes.return_reply(kattypes.Int())
-    def request_sensor_list(self, req, msg):
-        if msg.arguments:
-            name = (msg.arguments[0],)
-            keys = (name, )
-            if name not in self._sensor_infos:
-                return ("fail", "Unknown sensor name.")
-        else:
-            keys = self._sensor_infos.keys()
+    fake_katcp_client_resource : instance of faked subclass of KATCPClientResourceClass
+    fake_katcp_client_resource_manager : :class:`FakeKATCPClientResourceManager` instance
+        Bound to the `fake_katcp_client_resource` instance.
 
-        num_informs = 0
-        for sensor_name in keys:
-            infos = self._sensor_infos[sensor_name]
-            num_informs += 1
-            req.inform(sensor_name, *infos)
+    """
+    # TODO Implement allow_any_request functionality. When True, any unknown request (even
+    # if there is no fake implementation) should succeed
+    allow_any_request = fake_options.get('allow_any_request', False)
 
-        return ('ok', num_informs)
+    class FakeKATCPClientResource(KATCPClientResourceClass):
+        def inspecting_client_factory(self, host, port, ioloop_set_to):
+            real_instance = (super(FakeKATCPClientResource, self)
+                             .inspecting_client_factory(host, port, ioloop_set_to) )
+            fic, fic_manager = fake_inspecting_client_factory(
+                real_instance.__class__, fake_options, host, port,
+                ioloop=ioloop_set_to, auto_reconnect=self.auto_reconnect)
+            self.fake_inspecting_client_manager = fic_manager
+            return fic
+
+    fkcr = FakeKATCPClientResource(resource_spec, *args, **kwargs)
+    fkcr_manager = FakeKATCPClientResourceManager(fkcr)
+    return (fkcr, fkcr_manager)
+
+def fake_KATCP_client_resource_container_factory(
+        KATCPClientResourceContainerClass, fake_options, resources_spec,
+        *args, **kwargs):
+    """Create a fake KATCPClientResourceContainer-like class and a fake-manager
+
+    Parameters
+    ----------
+    KATCPClientResourceContainerClass : class
+        Subclass of :class:`katcp.resource_client.KATCPClientResourceContainer`
+    fake_options : dict
+        Options for the faking process. Keys:
+            allow_any_request : bool, default False
+            (TODO not implemented behaves as if it were True)
+    resources_spec, *args, **kwargs : passed to KATCPClientResourceContainerClass
+
+    A subclass of the passed-in KATCPClientResourceClassContainer is created that replaces the
+    KATCPClientResource child instances with fakes using fake_KATCP_client_resource_factory()
+    based on the KATCPClientResource class used by `KATCPClientResourceContainerClass`.
+
+    Returns
+    -------
+    (fake_katcp_client_resource_container, fake_katcp_client_resource_container_manager):
+
+    fake_katcp_client_resource_container : instance of faked subclass of
+                                           KATCPClientResourceContainerClass
+    fake_katcp_client_resource_manager : :class:`FakeKATCPClientResourceContainerManager`
+                                         instance
+        Bound to the `fake_katcp_client_resource_container` instance.
+
+    """
+    # TODO allow_any_request see comment in fake_KATCP_client_resource_factory()
+    allow_any_request = fake_options.get('allow_any_request', False)
+
+    class FakeKATCPClientResourceContainer(KATCPClientResourceContainerClass):
+        def __init__(self, *args, **kwargs):
+            self.fake_client_resource_managers = {}
+            super(FakeKATCPClientResourceContainer, self).__init__(*args, **kwargs)
+
+        def client_resource_factory(self, res_spec, parent, logger):
+            real_instance = (super(FakeKATCPClientResourceContainer, self)
+                             .client_resource_factory(res_spec, parent, logger) )
+            fkcr, fkcr_manager = fake_KATCP_client_resource_factory(
+                real_instance.__class__, fake_options,
+                res_spec, parent=self, logger=logger)
+            self.fake_client_resource_managers[
+                resource.escape_name(fkcr.name)] = fkcr_manager
+            return fkcr
+
+    fkcrc = FakeKATCPClientResourceContainer(resources_spec, *args, **kwargs)
+    fkcrc_manager = FakeKATCPClientResourceContainerManager(fkcrc)
+    return (fkcrc, fkcrc_manager)
+
+
+class FakeKATCPClientResourceManager(object):
+    """Manage a fake KATCPClientResource instance"""
+    def __init__(self, fake_katcp_resource_client):
+        self._fkrc = fake_katcp_resource_client
+
+    @property
+    def _fic_manager(self):
+        try:
+           fic_manager = self._fkrc.fake_inspecting_client_manager
+        except AttributeError:
+            raise RuntimeError(
+                'Fake KATCPClientResource must be started before it can be managed')
+        return fic_manager
+
+    @property
+    def fake_sensor_infos(self):
+        return self._fic_manager.fake_sensor_infos
 
     def add_sensors(self, sensor_infos):
         """Add fake sensors
@@ -62,19 +139,169 @@ class FakeInspectingClientManager(object):
         stringifying them.
 
         """
-        self._sensor_infos.update(sensor_infos)
+        self._fic_manager.add_sensors(sensor_infos)
+
+    def add_request_handlers_object(self, rh_obj):
+        """Add fake request handlers from an object with request_* method(s)
+
+        See :class:`FakeInspectingClientManager` for detail
+        """
+        return self._fic_manager.add_request_handlers_object(rh_obj)
+
+    def add_request_handlers_dict(self, rh_dict):
+        """Add fake request handlers from a dict keyed by request name
+
+        See :class:`FakeInspectingClientManager` for detail
+        """
+        return self._fic_manager.add_request_handlers_dict(rh_dict)
+
+class FakeKATCPClientResourceContainerManager(object):
+    def __init__(self, fake_katcp_resource_container):
+        self._fkcrc = fake_katcp_resource_container
+
+    @property
+    def child_managers(self):
+        return self._fkcrc.fake_client_resource_managers
+
+    def add_sensors(self, child_name, sensor_infos):
+        """Add fake sensors
+
+        child_name : str
+            Name of the client to which the sensor should be added as used in the keys of
+            the FakeKATCPClientResourceContainer `children` container.
+        sensor_infos is a dict <sensor-name> : (
+            <description>, <unit>, <sensor-type>, <params>*)
+        The sensor info is string-reprs of whatever they are, as they would be on
+        the wire in a real KATCP connection. Values are passed to a katcp.Message object,
+        so some automatic conversions are done, hence it is OK to pass numbers without
+        stringifying them.
+
+        """
+        self.child_managers[child_name].add_sensors(sensor_infos)
+
+    def add_request_handlers_object(self, child_name, rh_obj):
+        """Add fake request handlers from an object with request_* method(s)
+
+        See :class:`FakeInspectingClientManager` for detail
+        """
+        return self.child_managers[child_name].add_request_handlers_object(rh_obj)
+
+    def add_request_handlers_dict(self, rh_dict):
+        """Add fake request handlers from a dict keyed by request name
+
+        See :class:`FakeInspectingClientManager` for detail
+        """
+        return self.child_managers[child_name].add_request_handlers_dict(rh_dict)
+
+def fake_inspecting_client_factory(InspectingClass, fake_options, host, port,
+                                   *args, **kwargs):
+    # Note, that this mechanism makes many assumptions about the internals of
+    # InspectingClientAsync and DeviceClient, so it may well break if substantial changes
+    # are made to the implementation of either.
+
+    allow_any_request = fake_options.get('allow_any_request', False)
+    # TODO Implement any request stuff. See comment above in
+    # fake_KATCP_client_resource_factory
+
+
+    class FakeInspectingClass(InspectingClass):
+        def inform_hook_client_factory(self, host, port, *args, **kwargs):
+            fac = FakeAsyncClient(host, port, *args, **kwargs)
+            # We'll be ignoring the inform hooks, rather stimulating the InspectingClass at a
+            # higher level
+            fac.hook_inform = lambda *x, **xx : None
+            return fac
+
+    fic = FakeInspectingClass(host, port, *args, **kwargs)
+    fic_manager = FakeInspectingClientManager(fic)
+    return (fic, fic_manager)
+
+class FakeInspectingClientManager(object):
+    def __init__(self, fake_inspecting_client):
+        self._fic = fake_inspecting_client
+        self._fkc = fake_inspecting_client.katcp_client
+        self.add_request_handlers_object(self)
+        self.fake_sensor_infos = {}
+
+    @kattypes.return_reply(kattypes.Int())
+    def request_sensor_list(self, req, msg):
+        """Sensor list"""
+        if msg.arguments:
+            name = (msg.arguments[0],)
+            keys = (name, )
+            if name not in self.fake_sensor_infos:
+                return ("fail", "Unknown sensor name.")
+        else:
+            keys = self.fake_sensor_infos.keys()
+
+        num_informs = 0
+        for sensor_name in keys:
+            infos = self.fake_sensor_infos[sensor_name]
+            num_informs += 1
+            req.inform(sensor_name, *infos)
+
+        return ('ok', num_informs)
+
+    @property
+    def _request_handlers(self):
+        """For compatibility with methods stolen from server.DeviceServer"""
+        return self._fkc.request_handlers
+
+    request_help = server.DeviceServer.request_help.im_func
+
+    def add_sensors(self, sensor_infos):
+        """Add fake sensors
+
+        sensor_infos is a dict <sensor-name> : (
+            <description>, <unit>, <sensor-type>, <params>*)
+        The sensor info is string-reprs of whatever they are, as they would be on
+        the wire in a real KATCP connection. Values are passed to a katcp.Message object,
+        so some automatic conversions are done, hence it is OK to pass numbers without
+        stringifying them.
+
+        """
+        # Check sensor validity. parse_type() and parse_params should raise if not OK
+        for s_name, s_info in sensor_infos.items():
+            s_type = Sensor.parse_type(s_info[2])
+            s_params = Sensor.parse_params(s_type, s_info[3:])
+        self.fake_sensor_infos.update(sensor_infos)
         self._fic._interface_changed.set()
 
     def add_request_handlers_object(self, rh_obj):
+        """Add fake request handlers from an object with request_* method(s)
+
+        See :meth:`FakeInspectingClientManager.add_request_handlers_dict` for more detail.
+
+        """
+        rh_dict = {}
         for name in dir(rh_obj):
             if not callable(getattr(rh_obj, name)):
                 continue
             if name.startswith("request_"):
                 request_name = convert_method_name("request_", name)
-                self._fkc.request_handlers[request_name] = getattr(rh_obj, name)
+                req_meth = getattr(rh_obj, name)
+                # Check that all the handlers have docstrings as strings
+                assert req_meth.__doc__, "Even fake request handlers must have docstrings"
+                rh_dict[request_name] = req_meth
+
+        self.add_request_handlers_dict(rh_dict)
 
     def add_request_handlers_dict(self, rh_dict):
+        """Add fake request handler functions from a dict keyed by request name
+
+        Note the keys must be the KATCP message name (i.e. "the-request", not
+        "the_request")
+
+        The request-handler interface is more or less compatible with request handler API
+        in :class:`katcp.server.DeviceServerBase`. The fake ClientRequestConnection req
+        object does not support mass_inform() or reply_with_message.
+
+        """
+        # Check that all the callables have docstrings as strings
+        for req_func in rh_dict.values():
+            assert req_func.__doc__, "Even fake request handlers must have docstrings"
         self._fkc.request_handlers.update(rh_dict)
+        self._fic._interface_changed.set()
 
 class FakeKATCPServerError(Exception):
     """Raised if a FakeKATCPServer is used in an unsupported way"""

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -1,0 +1,151 @@
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
+import tornado.concurrent
+
+from thread import get_ident as get_thread_ident
+
+from tornado.gen import Return
+
+from katcp import client
+from katcp.core import AttrDict, ProtocolFlags, Message
+
+def get_fake_inspecting_client_instance(InspectingClass, host, port, *args, **kwargs):
+    # katcp methods used:
+    #
+    #  set_ioloop()
+    #  hook_inform(): sensor-status, interface-changed, device-changed
+    #  is_connected()
+    #  until_protocol()
+    #  until_connected()
+    #  disconnect()
+    #  start()
+    #  stop()
+    #  join()
+    #  future_request()
+    #
+    # attributes:
+    #
+    #  protocol_flags
+
+    # Note, that this mechanism makes many assumptions about the internals of
+    # InspectingClientAsync and DeviceClient, so it may well break if substantial changes
+    # are made to the implementation of either
+    class FakeInspectingClass(InspectingClass):
+        def get_inform_hook_client(self, host, port, *args, **kwargs):
+            fac = FakeAsyncClient(host, port, *args, **kwargs)
+            # We'll be ignoring the inform hooks, rather stimulating the InspectingClass at a
+            # higher level
+            fac.hook_inform = lambda *x, **xx : None
+            return fac
+
+    ic = FakeInspectingClass(host, port, *args, **kwargs)
+
+    return ic
+
+class FakeInspectingClientManager(object):
+    def __init__(self, fake_inspecting_client):
+        self._fic = fake_inspecting_client
+        self._fkc = fake_inspecting_client.katcp_client
+        self._fkc.request_handlers['sensor-list'] = self.handle_sensor_list
+        self._sensor_infos = {}
+
+    @tornado.gen.coroutine
+    def handle_sensor_list(self, msg):
+        if msg.arguments:
+            name = (msg.arguments[0],)
+            keys = (name, )
+            if name not in self._sensor_infos:
+                raise Return((Message.reply(msg.name, 'fail', 'Sensor not found'), []))
+        else:
+            keys = self._sensor_infos.keys()
+
+        informs = []
+        for sensor_name in keys:
+            infos = self._sensor_infos[sensor_name]
+            informs.append(Message.inform(msg.name, sensor_name, *infos, mid=msg.mid))
+
+        raise Return((Message.reply(msg.name, 'ok', len(informs), mid=msg.mid),
+                      informs))
+
+    def add_sensors(self, sensor_infos):
+        """Add fake sensors
+
+        sensor_infos is a dict <sensor-name> : (
+            <description>, <unit>, <sensor-type>, <params>*)
+        The sensor info is string-reprs of whatever they are, as they would be on
+        the wire in a real KATCP connection. Values are passed to a katcp.Message object,
+        so some automatic conversions are done, hence it is OK to pass numbers without
+        stringifying them.
+
+        """
+        self._sensor_infos.update(sensor_infos)
+        self._fic._interface_changed.set()
+
+class FakeAsyncClient(client.AsyncClient):
+    """Fake version of :class:`katcp.client.AsyncClient`
+
+    Useful for testing and simulation
+
+    By default assumes that the client is connected to a fully featured KATCPv5
+    server. Call preset_protocol_flags() to override
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.request_handlers = {}
+        super(FakeAsyncClient, self).__init__(*args, **kwargs)
+
+    @tornado.gen.coroutine
+    def _install(self):
+        self.ioloop_thread_id = get_thread_ident()
+        self._running.set()
+        yield self._connect()
+
+    @tornado.gen.coroutine
+    def _connect(self):
+        assert get_thread_ident() == self.ioloop_thread_id
+        self._stream = AttrDict(error=None)
+        self._connected.set()
+        self.notify_connected(True)
+        self.preset_protocol_flags(ProtocolFlags(5, 0, set('IM')))
+
+    def _disconnect(self):
+        if self._stream:
+            self._stream_closed_callback(self._stream)
+
+    @tornado.gen.coroutine
+    def future_request(self, msg, timeout=None, use_mid=None):
+        """Send a request messsage, with future replies.
+
+        Parameters
+        ----------
+        msg : Message object
+            The request Message to send.
+        timeout : float in seconds
+            How long to wait for a reply. The default is the
+            the timeout set when creating the AsyncClient.
+        use_mid : boolean, optional
+            Whether to use message IDs. Default is to use message IDs
+            if the server supports them.
+
+        Returns
+        -------
+        A tornado.concurrent.Future that resolves with:
+
+        reply : Message object
+            The reply message received.
+        informs : list of Message objects
+            A list of the inform messages received.
+
+        """
+        mid = self._get_mid_and_update_msg(msg, use_mid)
+
+        if msg.name in self.request_handlers:
+            reply_msg, reply_informs = yield tornado.gen.maybe_future(
+                self.request_handlers[msg.name](msg))
+        else:
+            reply_msg = Message.reply(msg.name, 'ok')
+            reply_informs = []
+
+        reply_msg.mid = mid
+        raise Return((reply_msg, reply_informs))
+

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -186,7 +186,7 @@ class FakeKATCPClientResourceContainerManager(object):
         """
         return self.child_managers[child_name].add_request_handlers_object(rh_obj)
 
-    def add_request_handlers_dict(self, rh_dict):
+    def add_request_handlers_dict(self, child_name, rh_dict):
         """Add fake request handlers from a dict keyed by request name
 
         See :class:`FakeInspectingClientManager` for detail
@@ -280,8 +280,6 @@ class FakeInspectingClientManager(object):
             if name.startswith("request_"):
                 request_name = convert_method_name("request_", name)
                 req_meth = getattr(rh_obj, name)
-                # Check that all the handlers have docstrings as strings
-                assert req_meth.__doc__, "Even fake request handlers must have docstrings"
                 rh_dict[request_name] = req_meth
 
         self.add_request_handlers_dict(rh_dict)

--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -126,7 +126,7 @@ class InspectingClientAsync(object):
         self._running = False
 
         # Setup KATCP device.
-        self.katcp_client = self.get_inform_hook_client(
+        self.katcp_client = self.inform_hook_client_factory(
             host, port, auto_reconnect=auto_reconnect, logger=logger)
         self.ioloop = ioloop or tornado.ioloop.IOLoop.current()
         self.katcp_client.set_ioloop(ioloop)
@@ -164,7 +164,7 @@ class InspectingClientAsync(object):
     def __del__(self):
         self.close()
 
-    def get_inform_hook_client(self, host, port, *args, **kwargs):
+    def inform_hook_client_factory(self, host, port, *args, **kwargs):
         """Return an instance of :class:`_InformHookDeviceClient` or similar
 
         Provided to ease testing. Dynamically overriding this method after instantiation
@@ -298,7 +298,6 @@ class InspectingClientAsync(object):
                                        model_changed=False, data_synced=True)
                 yield until_any(self._interface_changed.until_set(),
                                 self._disconnected.until_set())
-                print ('interface changed or disconnected')
                 self._interface_changed.clear()
                 continue
                 # Next loop through should cause re-inspection and handle state updates

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -20,7 +20,7 @@ from peak.util.proxies import ObjectWrapper
 from katcp import resource, inspecting_client, Message
 from katcp.resource import KATCPReply, KATCPSensorError
 from katcp.core import (AttrDict, AsyncCallbackEvent, steal_docstring_from,
-                        AsyncState)
+                        AsyncState, until_any)
 
 log = logging.getLogger(__name__)
 
@@ -140,7 +140,8 @@ class ReplyWrappedInspectingClientAsync(inspecting_client.InspectingClientAsync)
         try:
             use_mid = kwargs.get('use_mid')
             timeout = kwargs.get('timeout')
-            msg = Message.request(request, *args)
+            mid = kwargs.get('mid')
+            msg = Message.request(request, *args, mid=mid)
         except Exception:
             f.set_exc_info(sys.exc_info())
             return f
@@ -288,7 +289,7 @@ class KATCPClientResource(resource.KATCPResource):
     def start(self):
         """Start the client and connect"""
         host, port = self.address
-        ic = self._inspecting_client = self.get_inspecting_client(
+        ic = self._inspecting_client = self.inspecting_client_factory(
             host, port, self._ioloop_set_to)
         self.ioloop = ic.ioloop
         ic.katcp_client.auto_reconnect_delay = self.auto_reconnect_delay
@@ -302,12 +303,12 @@ class KATCPClientResource(resource.KATCPResource):
         self.reapply_sampling_strategies = self._sensor_manager.reapply_sampling_strategies
         log_future_exceptions(self._logger, ic.connect())
 
-    def get_inspecting_client(self, host, port, ioloop_set_to):
+    def inspecting_client_factory(self, host, port, ioloop_set_to):
         """Return an instance of :class:`ReplyWrappedInspectingClientAsync` or similar
 
         Provided to ease testing. Dynamically overriding this method after instantiation
         but before start() is called allows for deep brain surgery. See
-        :class:`katcp.fake_clients.TBD`
+        :class:`katcp.fake_clients.fake_inspecting_client_factory`
 
         """
         return ReplyWrappedInspectingClientAsync(
@@ -655,9 +656,19 @@ class KATCPClientResourceContainer(resource.KATCPResource):
             # Make a copy since we'll be modifying the dict
             res_spec = dict(res_spec)
             res_spec['name'] = res_name
-            res = KATCPClientResource(res_spec, parent=self, logger=self._logger)
+            res = self.client_resource_factory(
+                res_spec, parent=self, logger=self._logger)
             children[resource.escape_name(res_name)] = res
         self._children = children
+
+    def client_resource_factory(self, res_spec, parent, logger):
+        """Return an instance of :class:`KATCPClientResource` or similar
+
+        Provided to ease testing. Overriding this method allows deep brain surgery. See
+        :func:`katcp.fake_clients.fake_KATCP_client_resource_factory`
+
+        """
+        return KATCPClientResource(res_spec, parent=self, logger=logger)
 
     def _init_groups(self):
         group_configs = self._resources_spec.get('groups', {})
@@ -689,6 +700,15 @@ class KATCPClientResourceContainer(resource.KATCPResource):
     def until_synced(self):
         """Return a tornado Future; resolves when all subordinate clients are synced"""
         yield [r.until_synced() for r in dict.values(self.children)]
+
+    def until_any_child_in_state(self, state):
+        """Return a tornado Future; resolves when any client is in specified state"""
+        return until_any(*[r.until_state(state) for r in dict.values(self.children)])
+
+    @tornado.gen.coroutine
+    def until_all_children_in_state(self, state):
+        """Return a tornado Future; resolves when all clients are in specified state"""
+        yield [r.until_state(state) for r in dict.values(self.children)]
 
     @steal_docstring_from(resource.KATCPResource.list_sensors)
     def list_sensors(self, filter="", strategy=False, status="",

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -4,14 +4,16 @@ from __future__ import division
 
 import unittest2 as unittest
 import logging
+import copy
 
 import tornado.testing
 import tornado.gen
 
-from katcp import Sensor
+from katcp import Sensor, resource_client
 from katcp.kattypes import request, return_reply, Int, Float
 from katcp.testutils import SensorComparisonMixin
 from katcp.inspecting_client import InspectingClientAsync
+from katcp.resource import escape_name
 
 # module under test
 from katcp import fake_clients
@@ -23,10 +25,9 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
         super(test_FakeInspectingClient, self).setUp()
         self.host = 'fake-host'
         self.port = 12345
-        self.fake_inspecting_client = fake_clients.get_fake_inspecting_client_instance(
-            InspectingClientAsync, self.host, self.port, ioloop=self.io_loop)
-        self.fake_inspecting_manager = fake_clients.FakeInspectingClientManager(
-            self.fake_inspecting_client)
+        self.fake_inspecting_client, self.fake_inspecting_manager = (
+            fake_clients.fake_inspecting_client_factory(
+            InspectingClientAsync, {}, self.host, self.port, ioloop=self.io_loop) )
 
     @tornado.testing.gen_test
     def test_sensors(self):
@@ -50,24 +51,28 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
             name='a-string', type=Sensor.STRING, description='A string sensor',
             params=[]))
 
+class FakeHandlers(object):
+    @request(Int(), Int())
+    @return_reply(Int())
+    def request_add_test(self, req, a, b):
+        "Add numbers"
+        req.inform(a*2, b*3)
+        return ('ok', a + b)
+
+    @request(Int(), Int())
+    @return_reply(Float())
+    @tornado.gen.coroutine
+    def request_async_divide(self, req, a, b):
+        "Divide numbers"
+        req.inform(a/2, b/10)
+        req.inform('polony-is-real meat')
+        raise tornado.gen.Return( ('ok', a / b) )
+
+
     @tornado.testing.gen_test
     def test_request_handlers(self):
-        class TestHandlers(object):
-            @request(Int(), Int())
-            @return_reply(Int())
-            def request_add_test(self, req, a, b):
-                req.inform(a*2, b*3)
-                return ('ok', a + b)
-
-            @request(Int(), Int())
-            @return_reply(Float())
-            @tornado.gen.coroutine
-            def request_async_divide(self, req, a, b):
-                req.inform(a/2, b/10)
-                req.inform('polony-is-real meat')
-                raise tornado.gen.Return( ('ok', a / b) )
-
-        test_handlers = TestHandlers()
+        yield self.fake_inspecting_client.connect()
+        test_handlers = FakeHandlers()
 
         self.fake_inspecting_manager.add_request_handlers_object(test_handlers)
         reply, informs = yield self.fake_inspecting_client.simple_request(
@@ -81,4 +86,95 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
         self.assertEqual(str(informs[0]), '#async-divide[112] {} {}'
                          .format(7/2, 2/10))
         self.assertEqual(str(informs[1]), '#async-divide[112] polony-is-real\\_meat')
+
+
+class test_FakeKATCPClientResource(tornado.testing.AsyncTestCase):
+    def setUp(self):
+        super(test_FakeKATCPClientResource, self).setUp()
+        self.resource_spec = dict(
+            name='testdev',
+            description='resource for testing',
+            address=('testhost', 12345),
+            controlled=True)
+
+    @tornado.testing.gen_test
+    def test_sensors(self):
+        DUT, DUT_manager = fake_clients.fake_KATCP_client_resource_factory(
+            resource_client.KATCPClientResource, {}, dict(self.resource_spec))
+        DUT.start()
+        yield DUT.until_synced()
+        self.assertEqual(len(DUT.sensor), 0)
+        sensor_info = {
+            'an-int': ('An integer sensor', 'things', 'integer', 0, 10),
+            'a-string' : ('A string sensor', '', 'string'),
+        }
+        DUT_manager.add_sensors(sensor_info)
+        yield DUT.until_state('syncing')
+        yield DUT.until_synced()
+        self.assertEqual(len(DUT.sensor), 2)
+        self.assertEqual(sorted(dict.keys(DUT.sensor)), ['a_string', 'an_int'])
+
+class test_FakeKATCPClientResourceContainer(tornado.testing.AsyncTestCase):
+    def setUp(self):
+        super(test_FakeKATCPClientResourceContainer, self).setUp()
+        self.resources_spec = dict(clients={
+            'client1': dict(address=('client1-addr', 1234), controlled=True),
+            'client-2': dict(address=('client2-addr', 1235), controlled=False),
+            'another-client': dict(address=('another-addr', 1231), controlled=True)},
+                                   name='test-container',
+                                   description='container for testing')
+    @tornado.testing.gen_test
+    def test_sensors(self):
+        DUT, DUT_manager = fake_clients.fake_KATCP_client_resource_container_factory(
+            resource_client.KATCPClientResourceContainer, {},
+            copy.deepcopy(self.resources_spec))
+        sensor_info = {
+            'an-int': ('An integer sensor', 'things', 'integer', 0, 10),
+            'a-string' : ('A string sensor', '', 'string'),
+        }
+        DUT.start()
+        self.assertEqual(len(DUT.sensor), 0)
+        DUT_manager.add_sensors('client_2', sensor_info)
+        yield DUT.until_any_child_in_state('syncing')
+        yield DUT.until_synced()
+        self.assertEqual(sorted(dict.keys(DUT.sensor)),
+                         ['client_2_a_string', 'client_2_an_int'])
+        client1_sensor_info = dict(sensor_info)
+        client1_sensor_info['uniquely-1'] = ('Unique client2 sensor', '', 'boolean')
+        DUT_manager.add_sensors('client1', client1_sensor_info)
+        yield DUT.until_any_child_in_state('syncing')
+        yield DUT.until_synced()
+        # TODO test value setting also
+
+    @tornado.testing.gen_test
+    def test_requests(self):
+        DUT, DUT_manager = fake_clients.fake_KATCP_client_resource_container_factory(
+            resource_client.KATCPClientResourceContainer, {},
+            copy.deepcopy(self.resources_spec))
+        DUT.start()
+        yield DUT.until_any_child_in_state('syncing')
+        yield DUT.until_synced()
+        # Check the standard requests as implemented by
+        # fake_clients.FakeInspectingClientManager. Expect this test to break if
+        # FakeInspectingClientManager implements more requests.
+        standard_requests = ('help', 'sensor_list')
+        controlled_clients = [
+            escape_name(c_name) for c_name, c in self.resources_spec['clients'].items()
+            if c.get('controlled')]
+        desired_requests = sorted(
+            escape_name(c)+'_'+r for c in controlled_clients for r in standard_requests)
+        self.assertEqual(sorted(DUT.req.keys()), desired_requests)
+
+        # Now add some requests
+        DUT_manager.add_request_handlers_object('client1', FakeHandlers())
+        yield DUT.until_any_child_in_state('syncing')
+        yield DUT.until_synced()
+
+        desired_requests += ['client1_add_test', 'client1_async_divide']
+        desired_requests.sort()
+        self.assertEqual(sorted(DUT.req.keys()), desired_requests)
+        reply, informs = yield DUT.req.client1_add_test(1, 5, mid='1233')
+        self.assertEqual(len(informs), 1)
+        self.assertEqual(str(informs[0]), '#add-test[1233] 2 15')
+        self.assertEqual(str(reply), '!add-test[1233] ok 6')
 

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -1,18 +1,24 @@
 # Copyright 2015 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
+from __future__ import division
 
 import unittest2 as unittest
 import logging
 
 import tornado.testing
+import tornado.gen
 
+from katcp import Sensor
+from katcp.kattypes import request, return_reply, Int, Float
+from katcp.testutils import SensorComparisonMixin
 from katcp.inspecting_client import InspectingClientAsync
 
 # module under test
 from katcp import fake_clients
 
 
-class test_FakeInspectingClient(tornado.testing.AsyncTestCase):
+class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
+                                SensorComparisonMixin):
     def setUp(self):
         super(test_FakeInspectingClient, self).setUp()
         self.host = 'fake-host'
@@ -35,6 +41,44 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase):
         yield self.fake_inspecting_client.until_synced()
 
         an_int = yield self.fake_inspecting_client.future_get_sensor('an-int')
-        self.assertEqual
+        s_description, s_units = sensor_info['an-int'][0:2]
+        self.assert_sensor_equal_description(an_int, dict(
+            name='an-int', type=Sensor.INTEGER, description='An integer sensor',
+            params=[0, 10]))
         a_string = yield self.fake_inspecting_client.future_get_sensor('a-string')
-        import IPython ; IPython.embed()
+        self.assert_sensor_equal_description(a_string, dict(
+            name='a-string', type=Sensor.STRING, description='A string sensor',
+            params=[]))
+
+    @tornado.testing.gen_test
+    def test_request_handlers(self):
+        class TestHandlers(object):
+            @request(Int(), Int())
+            @return_reply(Int())
+            def request_add_test(self, req, a, b):
+                req.inform(a*2, b*3)
+                return ('ok', a + b)
+
+            @request(Int(), Int())
+            @return_reply(Float())
+            @tornado.gen.coroutine
+            def request_async_divide(self, req, a, b):
+                req.inform(a/2, b/10)
+                req.inform('polony-is-real meat')
+                raise tornado.gen.Return( ('ok', a / b) )
+
+        test_handlers = TestHandlers()
+
+        self.fake_inspecting_manager.add_request_handlers_object(test_handlers)
+        reply, informs = yield self.fake_inspecting_client.simple_request(
+            'add-test', 1, 5, mid='123')
+        self.assertEqual(len(informs), 1)
+        self.assertEqual(str(informs[0]), '#add-test[123] 2 15')
+        self.assertEqual(str(reply), '!add-test[123] ok 6')
+        reply, informs = yield self.fake_inspecting_client.simple_request(
+            'async-divide', 7, 2, mid='112')
+        self.assertEqual(len(informs), 2)
+        self.assertEqual(str(informs[0]), '#async-divide[112] {} {}'
+                         .format(7/2, 2/10))
+        self.assertEqual(str(informs[1]), '#async-divide[112] polony-is-real\\_meat')
+

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -1,0 +1,40 @@
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
+
+import unittest2 as unittest
+import logging
+
+import tornado.testing
+
+from katcp.inspecting_client import InspectingClientAsync
+
+# module under test
+from katcp import fake_clients
+
+
+class test_FakeInspectingClient(tornado.testing.AsyncTestCase):
+    def setUp(self):
+        super(test_FakeInspectingClient, self).setUp()
+        self.host = 'fake-host'
+        self.port = 12345
+        self.fake_inspecting_client = fake_clients.get_fake_inspecting_client_instance(
+            InspectingClientAsync, self.host, self.port, ioloop=self.io_loop)
+        self.fake_inspecting_manager = fake_clients.FakeInspectingClientManager(
+            self.fake_inspecting_client)
+
+    @tornado.testing.gen_test
+    def test_sensors(self):
+        sensor_info = {
+            'an-int': ('An integer sensor', 'things', 'integer', 0, 10),
+            'a-string' : ('A string sensor', '', 'string'),
+        }
+
+        yield self.fake_inspecting_client.connect()
+        self.fake_inspecting_manager.add_sensors(sensor_info)
+        yield self.fake_inspecting_client.until_not_synced()
+        yield self.fake_inspecting_client.until_synced()
+
+        an_int = yield self.fake_inspecting_client.future_get_sensor('an-int')
+        self.assertEqual
+        a_string = yield self.fake_inspecting_client.future_get_sensor('a-string')
+        import IPython ; IPython.embed()

--- a/katcp/test/test_inspectclient.py
+++ b/katcp/test/test_inspectclient.py
@@ -357,9 +357,11 @@ class TestInspectingClientAsyncStateCallback(tornado.testing.AsyncTestCase):
         self.assertEqual(state, inspecting_client.InspectingClientStateType(
             connected=True, synced=False, model_changed=False, data_synced=False))
         self.assertIs(model_changes, None)
-        # Due to the structure of the state loop the initial state is sent twice, hence +
-        # 2. If the implmentation changes having + 1 would also be OK.
-        yield self._check_no_cb(num_calls_before + 2)
+        # Due to the structure of the state loop the initial state may be sent twice
+        # before we get her, and was the case for the initial implementation. Changes made
+        # on 2015-01-26 caused it to happy only once, hence + 1. If the implementation
+        # changes having + 2 would also be OK.
+        yield self._check_no_cb(num_calls_before + 1)
 
         # Now let the server send #version-connect informs
         num_calls_before = len(self.done_state_cb_futures)

--- a/katcp/test/test_kattypes.py
+++ b/katcp/test/test_kattypes.py
@@ -517,11 +517,6 @@ class TestDevice(object):
     def inform_one(self, req, i, d, b):
         pass
 
-    @request(Int(min=1, max=3), Discrete(("on", "off")), Bool())
-    @return_reply(Int(min=1, max=3), Discrete(("on", "off")), Bool())
-    def request_five(self, i, d, b):
-        return ("ok", i, d, b)
-
     @request(Timestamp(), Timestamp(optional=True), major=4)
     @return_reply(Timestamp(), Timestamp(default=321), major=4)
     def request_katcpv4_time(self, req, timestamp1, timestamp2):
@@ -537,16 +532,6 @@ class TestDevice(object):
     def request_katcpv4_time_multi(self, req, *timestamps):
         self.katcpv4_time_multi = timestamps
         return ('ok',) + timestamps
-
-    @return_reply(Int(min=1, max=3), Discrete(("on", "off")), Bool())
-    @request(Int(min=1, max=3), Discrete(("on", "off")), Bool())
-    def request_six(self, i, d, b):
-        return ("ok", i, d, b)
-
-    @return_reply(Int(), Str())
-    @request(Int(), include_msg=True)
-    def request_seven(self, msg, i):
-        return ("ok", i, msg.name)
 
     @return_reply(Int(), Str())
     @request(Int(), include_msg=True)
@@ -684,41 +669,6 @@ class TestDecorator(unittest.TestCase):
         req = ""
         self.assertEqual(self.device.inform_one(req, Message.inform(
                          "one", "2", "on", "0")), None)
-
-    def test_request_five(self):
-        """Test client request with no req."""
-        self.assertEqual(str(self.device.request_five(Message.request(
-                         "five", "2", "on", "0"))), "!five ok 2 on 0")
-        self.assertRaises(FailReply, self.device.request_five,
-                          Message.request("five", "14", "on", "0"))
-        self.assertRaises(FailReply, self.device.request_five,
-                          Message.request("five", "2", "dsfg", "0"))
-        self.assertRaises(FailReply, self.device.request_five,
-                          Message.request("five", "2", "on", "3"))
-        self.assertRaises(FailReply, self.device.request_five,
-                          Message.request("five", "2", "on", "0", "3"))
-
-        self.assertRaises(FailReply, self.device.request_five,
-                          Message.request("five", "2", "on"))
-
-    def test_request_six(self):
-        """Test client request with no req and decorators in reverse order."""
-        self.assertEqual(str(self.device.request_six(Message.request(
-                         "six", "2", "on", "0"))), "!six ok 2 on 0")
-        self.assertRaises(FailReply, self.device.request_six,
-                          Message.request("six", "4", "on", "0"))
-        self.assertRaises(FailReply, self.device.request_six,
-                          Message.request("six", "2", "dsfg", "0"))
-        self.assertRaises(FailReply, self.device.request_six,
-                          Message.request("six", "2", "on", "3"))
-
-        self.assertRaises(FailReply, self.device.request_six,
-                          Message.request("six", "2", "on"))
-
-    def test_request_seven(self):
-        """Test client request with no req but with a message."""
-        self.assertEqual(str(self.device.request_seven(Message.request(
-                         "seven", "7"))), "!seven ok 7 seven")
 
     def test_request_eight(self):
         """Test server request with a message argument."""

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -81,7 +81,7 @@ class test_KATCPClientresourceRequest(unittest.TestCase):
             'the-request', 'parm1', 2)
         self.assertIs(reply, self.mock_client.wrapped_request.return_value)
 
-class test_KATCPClientresource(tornado.testing.AsyncTestCase):
+class test_KATCPClientResource(tornado.testing.AsyncTestCase):
     def test_init(self):
         resource_spec = dict(
             name='testdev',
@@ -391,7 +391,7 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         self.default_spec = copy.deepcopy(self.default_spec_orig)
         super(test_KATCPClientResourceContainer, self).setUp()
 
-    @tornado.testing.gen_test(timeout=1000000)
+    @tornado.testing.gen_test
     def test_groups(self):
         spec = self.default_spec
         spec['groups'] = dict(group1=['client1', 'another-client'],


### PR DESCRIPTION
Functionality for clients that fake server connections on the client side. Useful for testing, and hopefully useful for kattelmod's time-warping telescope simulation, since all clients share the same ioloop allowing ioloop time-warp tricks to be used. Allows clients at the level op InspectingClient, KATCPClientResource and KATCPClientResourceContainer to be faked, with the ability for request-handlers and sensors to be installed on the 'fake' server.

@ludwigschwardt  FYI