### PR TITLE
Add ability to pre-set sensor strategies in KATCPResource.

### DIFF
--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -478,6 +478,11 @@ class InspectingClientAsync(object):
             If a katcp request to the server should be made to check if the
             sensor is on the server now.
 
+        Notes
+        -----
+        Ensure that self.state.data_synced == True if yielding to future_check_sensor from
+        a state-change callback, or a deadlock will occur.
+
         """
         exist = False
         yield self.until_data_synced()
@@ -508,6 +513,11 @@ class InspectingClientAsync(object):
         Returns
         -------
         Sensor created by :meth:`sensor_factory` or None if sensor not found.
+
+        Notes
+        -----
+        Ensure that self.state.data_synced == True if yielding to future_get_sensor from
+        a state-change callback, or a deadlock will occur.
 
         """
         obj = None
@@ -547,6 +557,11 @@ class InspectingClientAsync(object):
             sensor is on the server. True = Allow, False do not Allow, None
             use the class default.
 
+        Notes
+        -----
+        Ensure that self.state.data_synced == True if yielding to future_check_request
+        from a state-change callback, or a deadlock will occur.
+
         """
         exist = False
         yield self.until_data_synced()
@@ -576,6 +591,11 @@ class InspectingClientAsync(object):
         Returns
         -------
         Request created by :meth:`request_factory` or None if request not found.
+
+        Notes
+        -----
+        Ensure that self.state.data_synced == True if yielding to future_get_request
+        from a state-change callback, or a deadlock will occur.
 
         """
         obj = None

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -262,7 +262,6 @@ class KATCPResource(object):
                     False, sys.exc_info())
         raise tornado.gen.Return(sensors_strategies)
 
-    @tornado.gen.coroutine
     @abc.abstractmethod
     def preset_sensor_strategy(self, sensor_name, strategy_and_params):
         """Preset a strategy for a sensor even if it is not yet known
@@ -278,6 +277,18 @@ class KATCPResource(object):
         -------
         done : tornado Future
             Resolves when done
+        """
+
+    @abc.abstractmethod
+    def preset_sensor_listener(self, sensor_name, strategy_and_params):
+        """Preset a sensor listener for a sensor even if it is not yet known
+
+        sensor_name : str
+            Name of the sensor
+        listener : callable
+            Listening callble that will be registered on the named sensor when it becomes
+            available. Callable as for :meth:`KATCPSensor.register_listener`
+
         """
 
 class KATCPRequest(object):
@@ -585,6 +596,10 @@ class KATCPSensor(object):
         """
         listener_id = hashable_identity(listener)
         self._listeners.pop(listener_id, None)
+
+    def is_listener(self, listener):
+        listener_id = hashable_identity(listener)
+        return listener_id in self._listeners
 
     def clear_listeners(self):
         """Clear any registered listeners to updates from this sensor."""

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -262,6 +262,23 @@ class KATCPResource(object):
                     False, sys.exc_info())
         raise tornado.gen.Return(sensors_strategies)
 
+    @tornado.gen.coroutine
+    @abc.abstractmethod
+    def preset_sensor_strategy(self, sensor_name, strategy_and_params):
+        """Preset a strategy for a sensor even if it is not yet known
+
+        sensor_name : str
+            Name of the sensor
+        strategy_and_params : seq of str or str
+            As tuple contains (<strat_name>, [<strat_parm1>, ...]) where the strategy
+            names and parameters are as defined by the KATCP spec. As str contains the
+            same elements in space-separated form.
+
+        Returns
+        -------
+        done : tornado Future
+            Resolves when done
+        """
 
 class KATCPRequest(object):
     """Abstract Base class to serve as the definition of the KATCPRequest API.
@@ -404,7 +421,10 @@ class KATCPSensorsManager(object):
 
         This method should arrange for the strategy to be set on the underlying network
         device or whatever other implementation is used. This strategy should also be
-        automatically re-set if the device is reconnected, etc.
+        automatically re-set if the device is reconnected, etc. If a strategy is set for a
+        non-existing sensor, it should still cache the strategy and ensure that is applied
+        whenever said sensor comes into existance. This allows an applications to pre-set
+        strategies for sensors before synced / connected to a device.
 
         """
 
@@ -532,6 +552,11 @@ class KATCPSensor(object):
             As tuple contains (<strat_name>, [<strat_parm1>, ...]) where the strategy
             names and parameters are as defined by the KATCP spec. As str contains the
             same elements in space-separated form.
+
+        Returns
+        -------
+        done : tornado Future that resolves when done or raises KATCPSensorError
+
         """
         return self._manager.set_sampling_strategy(self.name, strategy)
 

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -758,6 +758,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
     @tornado.gen.coroutine
     @steal_docstring_from(resource.KATCPResource.preset_sensor_strategy)
     def preset_sensor_strategy(self, sensor_name, strategy_and_parms):
+        sensor_name = resource.escape_name(sensor_name)
         for child_name in dict.keys(self.children):
             prefix = child_name + '_'
             if sensor_name.startswith(prefix):

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -352,7 +352,7 @@ class KATCPClientResource(resource.KATCPResource):
                 yield sensor_obj.set_sampling_strategy(strategy_and_parms)
             except Exception:
                 self._logger.exception(
-                    'Uhandled exception trying to set sensor strategy {!r} for sensor {}'
+                    'Unhandled exception trying to set sensor strategy {!r} for sensor {}'
                     .format(sensor_name))
         else:
             # Otherwise, set for future reference, and depend on self._add_sensors() to


### PR DESCRIPTION
Allows strategies for sensors of interest to be set before they have appeared
(e.g. at app startup before the client has had a chance to sync, or if a dynamic
device has not made a given sensor available yet)