### PR TITLE
Store ioloop as KATCPClientResourceContainer attribute

### DIFF
--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -735,6 +735,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
         self._children_dirty = True   # Are we out of sync with the children?
         self._init_resources()
         self._init_groups()
+        self.set_ioloop()
 
     def _init_resources(self):
         resources = self._resources_spec['clients']
@@ -775,6 +776,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
         ioloop=None. Must be called before start()
         """
         ioloop = ioloop or tornado.ioloop.IOLoop.current()
+        self.ioloop = ioloop
         for res in dict.values(self.children):
             res.set_ioloop(ioloop)
 

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -928,6 +928,7 @@ class test_ThreadSafeKATCPClientResourceWrapper_container(unittest.TestCase):
     def setUp(self):
         self.ioloop_manager = ioloop_manager.IOLoopManager(managed_default=True)
         self.io_loop = self.ioloop_manager.get_ioloop()
+        self.io_loop.make_current()
 
         self.ioloop_thread_wrapper = resource_client.IOLoopThreadWrapper(self.io_loop)
         start_thread_with_cleanup(self, self.ioloop_manager, start_timeout=1)


### PR DESCRIPTION
Makes it easier for collaborating classes to be sure to use the correct ioloop.