### PR TITLE
Fix IOLoopManager.stop() to actually return a future

### DIFF
--- a/katcp/ioloop_manager.py
+++ b/katcp/ioloop_manager.py
@@ -147,6 +147,8 @@ class IOLoopManager(object):
             # Probably we have been shut-down already
             pass
 
+        return stopped_future
+
     def join(self, timeout=None):
         """Join managed ioloop thread, or do nothing if not managed."""
         if not self._ioloop_managed:


### PR DESCRIPTION
Also updated documentation with an async server example. The suggestion in the
previous commit was wrong, since ioloop.run_sync() does nor work properly if an
ioloop was ended by a KeyboardInterrupt. Here is a properly working example:

```py
@tornado.gen.coroutine
def on_shutdown(ioloop, server):
    print('Shutting down')
    yield server.stop()
    ioloop.stop()

if __name__ == "__main__":
    ioloop = tornado.ioloop.IOLoop.current()
    server = MyServer(server_host, server_port)
    server.set_concurrency_options(thread_safe=False, handler_thread=False)
    server.set_ioloop(ioloop)
    # Hook up to SIGINT so that ctrl-C results in a clean shutdown
    signal.signal(signal.SIGINT, lambda sig, frame: ioloop.add_callback_from_signal(
	  on_shutdown, ioloop, server))
    ioloop.add_callback(server.start)
    ioloop.start()
```