### PR TITLE
Changed reset_mock() signature to match base class

### DIFF
--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -1612,10 +1612,10 @@ class WaitingMock(mock.Mock):
         except Queue.Full:
             pass
 
-    def reset_mock(self):
+    def reset_mock(self, visited=None):
         # Re-set call_count as an AtomicIaddCallback instance since
         # the reset_mock() super-method does self.call_count=0
-        super(WaitingMock, self).reset_mock()
+        super(WaitingMock, self).reset_mock(visited)
         self.call_count = AtomicIaddCallback(
             self.call_count, callback=self._call_count_callback)
 


### PR DESCRIPTION
WaitingMock.reset_mock() could fail when invoked from mock.Mock()