### PR TITLE
Use request timeout in ioloop wrapper

### DIFF
--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1380,10 +1380,12 @@ class IOLoopThreadWrapper(object):
             # Should never get here since the tornado future should raise
             assert False, 'Tornado Future should have raised'
 
-    def decorate_callable(self, callable_, timeout=None):
+    def decorate_callable(self, callable_):
         """Decorate a callable to use call_in_ioloop"""
         @wraps(callable_)
         def decorated(*args, **kwargs):
+            # Extract timeout from request itself or use default for ioloop wrapper
+            timeout = kwargs.get('timeout')
             return self.call_in_ioloop(callable_, args, kwargs, timeout)
 
         decorated.__doc__ = '\n\n'.join((


### PR DESCRIPTION
The timeout parameter on the decorator itself is never used. Rather get rid
of it and extract the relevant timeout from the kwargs of the original request.
This way the user can override timeouts per request (as opposed to per ioloop
wrapper).

A future improvement might be to make the ioloop timeout slightly longer than
the request timeout to allow the request to drive the error reporting to the
user.

@brickZA to have a look as well.