### PR TITLE
exposed parse value on katcp resource

### DIFF
--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -657,7 +657,6 @@ class KATCPSensor(object):
         """
         return self._sensor.parse_value(s_value)
 
-
     def set_strategy(self, strategy, params=None):
         """Set current sampling strategy for sensor.
         Add this footprint for backwards compatibility.

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -640,6 +640,24 @@ class KATCPSensor(object):
     def type(self):
         return self._sensor.type
 
+    def parse_value(self, s_value):
+        """Parse a value from a string.
+
+        Parameters
+        ----------
+        s_value : str
+            A string value to attempt to convert to a value for
+            the sensor.
+
+        Returns
+        -------
+        value : object
+            A value of a type appropriate to the sensor.
+
+        """
+        return self._sensor.parse_value(s_value)
+
+
     def set_strategy(self, strategy, params=None):
         """Set current sampling strategy for sensor.
         Add this footprint for backwards compatibility.


### PR DESCRIPTION
Exposes parse_value from the _sensor on the katcp resource.

This is required for use as a replacement for the old format_type method.

please review and merge.