### PR TITLE
Add a client-side dummy-request facility CB-918

### DIFF
--- a/katcp/core.py
+++ b/katcp/core.py
@@ -14,7 +14,7 @@ import logging
 
 import tornado
 
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from functools import wraps, partial
 
 from concurrent.futures import Future, TimeoutError
@@ -1454,6 +1454,20 @@ class AttrDict(dict):
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
+
+class DefaultAttrDict(defaultdict):
+    """
+    Similar to AttrDict but adds `collections.defaultdict` functionality
+
+    Supports default values both for key and attribute access
+
+    """
+    def __init__(self, *args, **kwargs):
+        super(DefaultAttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+    def __getattr__(self, name):
+        return self[name]
 
 class AsyncEvent(object):
     """tornado.concurrent.Future Event based on threading.Event API

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -363,9 +363,6 @@ class KATCPRequest(object):
             KATCP name of the request
         description : str
             KATCP request description (as returned by ?help <name>)
-        client : client obj
-            KATCP client connected to the KATCP resource that exposes a wrapped_request()
-            method like :meth:`ReplyWrappedInspectingClientAsync.wrapped_request`.
         is_active : callable, optional
             Returns True if this request is active, else False
 
@@ -434,6 +431,14 @@ class KATCPRequest(object):
         """True if resource for this request is active"""
         return self._is_active()
 
+class KATCPDummyRequest(KATCPRequest):
+    """Dummy counterpart to KATCPRequest that always returns a successful reply"""
+    def issue_request(self, *args, **kwargs):
+        reply_msg = Message.reply('fake', 'ok')
+        reply = KATCPReply(reply_msg, [])
+        fut = Future()
+        fut.set_result(reply)
+        return fut
 
 class KATCPSensorReading(collections.namedtuple(
         'KATCPSensorReading', 'received_timestamp timestamp istatus value')):


### PR DESCRIPTION
@martinslabber @profcalculus Please have a look.

This implements the neccesary client side functionality to allow 'dummy-requests' to be done.  Next move would be modifying katsubarray to add the 'dummy_unknown_requests' flag to the resource client configuration dicts as appropriate.