### PR TITLE
New add_group method on container

### DIFF
--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1203,6 +1203,18 @@ class KATCPClientResourceContainer(resource.KATCPResource):
 
         self._groups = groups
 
+    def add_group(self, group_name, group_client_names):
+        """Add a new :class:`ClientGroup` to container groups member.
+
+        Add the group named *group_name* with sequence of client names to the
+        container groups member. From there it will be wrapped appropriately
+        in the higher-level thread-safe container.
+        """
+        group_configs = self._resources_spec.get('groups', {})
+        group_configs[group_name] = group_client_names
+        self._resources_spec['groups'] = group_configs
+        self._init_groups()
+
     def set_ioloop(self, ioloop=None):
         """Set the tornado ioloop to use
 

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -589,7 +589,9 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
                               group2=['client1', 'client-2'],
                               group3=['client1', 'client-2', 'another-client'])
         DUT = resource_client.KATCPClientResourceContainer(copy.deepcopy(spec))
-        self.assertEqual(sorted(DUT.groups), ['group1', 'group2', 'group3'])
+        DUT.add_group('group4', ('client-2', 'another-client'))
+        self.assertEqual(sorted(DUT.groups), ['group1', 'group2', 'group3', 'group4'])
+        spec['groups']['group4'] = ('client-2', 'another-client')
 
         for group_name, group in DUT.groups.items():
             # Smoke test that no errors are raised


### PR DESCRIPTION
This allows the dynamic addition of client groups on the container.
It does this by inserting the new group into the resource spec and updating
the groups property, which allows the higher-level thread-safe container
to wrap the new group properly.

There is no real need to remove groups as they are innocuous if they hang
around.