### PR TITLE
Add dummy unknown requests to ClientGroups

### DIFF
--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1316,7 +1316,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
 
     @tornado.gen.coroutine
     def set_sampling_strategy(self, sensor_name, strategy_and_parms):
-        """Set sampling strategies for the specific sensor - this sensor has to exsist"""
+        """Set sampling strategies for the specific sensor - this sensor has to exist"""
         result_list = yield self.list_sensors(filter="^"+sensor_name+"$") #exact match
         sensor_dict = {}
         for result in result_list:

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -132,7 +132,7 @@ class test_KATCPClientResource(tornado.testing.AsyncTestCase):
             # For real requests we expect a string, see
             # get_DUT_mock_inspecting_client() below.
             req = DUT_nodummy.req.req_one
-            self.assertEqual(req, 'req-one')
+            self.assertEqual(req.name, 'req-one')
 
         # Check that the non-dummy client doesn't have non-existing requests
         with self.assertRaises(AttributeError):

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -127,6 +127,9 @@ class test_KATCPClientResource(tornado.testing.AsyncTestCase):
             resource_spec_dummy)
         yield DUT_dummy._add_requests(requests)
         yield DUT_nodummy._add_requests(requests)
+        # Check dummy flag
+        self.assertFalse(DUT_nodummy.dummy_unknown_requests)
+        self.assertTrue(DUT_dummy.dummy_unknown_requests)
         # First check that actual requests are handled correctly
         for DUT in (DUT_nodummy, DUT_dummy):
             # For real requests we expect a string, see

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -120,12 +120,7 @@ class test_KATCPClientResource(tornado.testing.AsyncTestCase):
             controlled=True)
         resource_spec_dummy = dict(resource_spec_nodummy)
         resource_spec_dummy['dummy_unknown_requests'] = True
-        class SimpleRequest(str):
-            """Add description property to str to appease ClientGroup.req()"""
-            @property
-            def description(self):
-                return self
-        requests = (SimpleRequest('req-one'), SimpleRequest('req_two'))
+        requests = ('req-one', 'req_two')
         DUT_nodummy = self.get_DUT_mock_inspecting_client(
             resource_spec_nodummy)
         DUT_dummy = self.get_DUT_mock_inspecting_client(
@@ -174,7 +169,8 @@ class test_KATCPClientResource(tornado.testing.AsyncTestCase):
         ic = DUT._inspecting_client = mock.Mock()
         def future_get_request(key):
             f = tornado.concurrent.Future()
-            f.set_result(key)
+            req_obj = resource_client.KATCPClientResourceRequest(key, key, ic)
+            f.set_result(req_obj)
             return f
         ic.future_get_request.side_effect = future_get_request
         return DUT


### PR DESCRIPTION
ClientGroups have req objects and therefore also qualify for dummy
unknown requests. Since a group is not constructed from resource specs,
provide dummy requests if any of its underlying clients have them.