### PR TITLE
Avoid blocking python interpreter shutdown and avoid leaking file descriptors CB-1146

### DIFF
--- a/katcp/client.py
+++ b/katcp/client.py
@@ -656,7 +656,7 @@ class DeviceClient(object):
                     # changed that means this client has been stopped and re-started
                     # before we could get back to this finally clause. This would result
                     # in us stopping the new ioloop. D'oh!
-                    self.stop()
+                    self.ioloop.add_callback(self.stop)
             except RuntimeError, e:
                 if str(e) == 'IOLoop is closing':
                     # Seems the ioloop was stopped already, no worries.

--- a/katcp/ioloop_manager.py
+++ b/katcp/ioloop_manager.py
@@ -55,7 +55,7 @@ class IOLoopManager(object):
         def run_ioloop():
             try:
                 self._ioloop.start()
-                self._ioloop.close()
+                self._ioloop.close(all_fds=True)
             except Exception:
                 self._logger.error('Error running tornado IOloop: ',
                                    exc_info=True)


### PR DESCRIPTION
When the python interpreter exits it garbage collects all generators that still
exists. Sometimes (usually in tests when the test classes keep references to
everything) tornado coroutines (which are generators) might still exist in a
limbo state after the ioloop on which they were running has stopped. The client
has a finally statement in its main coroutine that tries to shutdown
cleanly. This does not work well when the ioloop has been stopped, and ends up
blocking the python interepreter exit for a second or so. Multiply by the number
of clients, this can be quite long at the end of a test run

By simply using add_callback to run the cleanup, nothing bad happens if the
ioloop is no longer running.