### PR TITLE
Allow high level clients to preset KATCP flags, allows broken servers

### DIFF
--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -15,7 +15,8 @@ from collections import namedtuple, defaultdict
 
 from tornado.gen import maybe_future, Return
 
-from katcp.core import AttrDict, until_any, future_timeout_manager
+from katcp.core import (AttrDict, until_any, future_timeout_manager,
+                        steal_docstring_from)
 
 ic_logger = logging.getLogger("katcp.inspect_client")
 RequestType = namedtuple('Request', 'name description')
@@ -200,6 +201,10 @@ class InspectingClientAsync(object):
     def synced(self):
         """Boolean indicating if the device has been synchronised."""
         return self._state.state.synced
+
+    @steal_docstring_from(_InformHookDeviceClient.preset_protocol_flags)
+    def preset_protocol_flags(self, protocol_flags):
+        self.katcp_client.preset_protocol_flags(protocol_flags)
 
     def set_ioloop(self, ioloop):
         self.katcp_client.set_ioloop(ioloop)

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -289,6 +289,9 @@ class KATCPClientResource(resource.KATCPResource):
               If true, provide dummy request functions for any unknown requests. Can be
               used as a rough simulation of a device for testing when some requests are
               not available.
+          preset_protocol_flags : :class:`katcp.core.ProtocolFlags` instance
+              Assume these protocol settings and ignore the server's
+              #katcp-protocol informs.
           # TODO(NM) 'keep', ie. katcorelib behaviour where requests / sensors never
           # disappear even if the device looses them. Or was it only sensors? Should look
           # at katcorelib
@@ -335,6 +338,7 @@ class KATCPClientResource(resource.KATCPResource):
 
         # Save the pop() / items() methods in case a sensor/request with the same name is
         # added
+        self._preset_protocol_flags = resource_spec.get('preset_protocol_flags')
         self._state = AsyncState(("disconnected", "syncing", "synced"))
         self._connected = AsyncCallbackEvent(self._update_state)
         self._sensors_synced = AsyncCallbackEvent(self._update_state)
@@ -390,6 +394,8 @@ class KATCPClientResource(resource.KATCPResource):
         ic = self._inspecting_client = self.inspecting_client_factory(
             host, port, self._ioloop_set_to)
         self.ioloop = ic.ioloop
+        if self._preset_protocol_flags:
+            ic.preset_protocol_flags(self._preset_protocol_flags)
         ic.katcp_client.auto_reconnect_delay = self.auto_reconnect_delay
         ic.set_state_callback(self._inspecting_client_state_callback)
         ic.request_factory = self._request_factory

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -26,7 +26,7 @@ from katcp.testutils import (DeviceTestServer, DeviceTestSensor,
                              TimewarpAsyncTestCaseTimeAdvancer)
 
 from katcp import resource, inspecting_client, ioloop_manager, Message, Sensor
-from katcp.core import AttrDict, AsyncEvent
+from katcp.core import AttrDict, AsyncEvent, ProtocolFlags
 
 # module under test
 from katcp import resource_client
@@ -802,6 +802,28 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
                 """A new command."""
                 return Message.reply(msg.name, "ok", "bling1", "bling2")
             s._request_handlers['sparkling-new-'+s_name] = handler
+
+    @tornado.testing.gen_test
+    def test_preset_protocol_flags(self):
+        pf1 = ProtocolFlags(4, 0, '')
+        pf2 = ProtocolFlags(5, 0, 'M')
+        pf3 = ProtocolFlags(5, 0, 'I')
+        clients = self.default_spec['clients']
+        clients['resource1']['preset_protocol_flags'] = pf1
+        clients['resource2']['preset_protocol_flags'] = pf2
+        clients['resource3']['preset_protocol_flags'] = pf3
+        DUT = resource_client.KATCPClientResourceContainer(self.default_spec)
+        DUT.start()
+        children = DUT.children
+        self.assertEqual(
+            children.resource1._inspecting_client.katcp_client.protocol_flags,
+            pf1)
+        self.assertEqual(
+            children.resource2._inspecting_client.katcp_client.protocol_flags,
+            pf2)
+        self.assertEqual(
+            children.resource3._inspecting_client.katcp_client.protocol_flags,
+            pf3)
 
     @tornado.testing.gen_test
     def test_timeout_of_until_synced(self):


### PR DESCRIPTION
To help with CBF tests