### PR TITLE
Clean up ClientGroup wait()

### DIFF
--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -197,18 +197,21 @@ class KATCPResource(object):
             Wait for this status, at the same time as value above, to be
             obtained. Ignore status if None
         timeout : float or None
-            The timeout in seconds
+            The timeout in seconds (None means wait forever)
 
         Returns
         -------
-        This command returns a tornado Future that resolves with True if the
-        sensor values satisifed the condition with the timeout, else resolves
-        with False.
+        This command returns a tornado Future that resolves with True when the
+        sensor value satisfies the condition. It will never resolve with False;
+        if a timeout is given a TimeoutError happens instead.
 
         Raises
         ------
-        Resolves with a :class:`KATCPSensorError` exception if the sensors does
-        not have a strategy set.
+        :class:`KATCPSensorError`
+            If the sensor does not have a strategy set, or if the named sensor
+            is not present
+        :class:`tornado.gen.TimeoutError`
+            If the sensor condition still fails after a stated timeout period
 
         """
         sensor_name = escape_name(sensor_name)
@@ -843,7 +846,7 @@ class KATCPSensor(object):
         raise Return(self._reading.status)
 
     def wait(self, condition_or_value, status=None, timeout=None):
-        """Wait for sensor to satisfy a condition.
+        """Wait for the sensor to satisfy a condition.
 
         Parameters
         ----------
@@ -853,30 +856,27 @@ class KATCPSensor(object):
             condition is satisfied. Since the reading is passed in, the value,
             status, timestamp or received_timestamp attributes can all be used
             in the check.
-
-            Sequences of conditions are TODO, use SensorTranstionWaiter thingum?
+            TODO: Sequences of conditions (use SensorTranstionWaiter thingum?)
         status : int enum, key of katcp.Sensor.SENSOR_TYPES or None
             Wait for this status, at the same time as value above, to be
             obtained. Ignore status if None
         timeout : float or None
-            The timeout in seconds
+            The timeout in seconds (None means wait forever)
 
         Returns
         -------
-        This command returns a tornado Future that resolves with True if the
-        sensor values satisifed the condition with the timeout, else resolves
-        with False.
+        This command returns a tornado Future that resolves with True when the
+        sensor value satisfies the condition. It will never resolve with False;
+        if a timeout is given a TimeoutError happens instead.
 
         Raises
         ------
-        Resolves with a :class:`KATCPSensorError` exception if the sensors does
-        not have a strategy set.
-
-        Resolves with :class:`tornado.gen.TimeoutError` if timeout is not None
-        and the sensor does not attain the requested value within the timeout.
+        :class:`KATCPSensorError`
+            If the sensor does not have a strategy set
+        :class:`tornado.gen.TimeoutError`
+            If the sensor condition still fails after a stated timeout period
 
         """
-
         if (isinstance(condition_or_value, collections.Sequence) and not
                 isinstance(condition_or_value, basestring)):
             raise NotImplementedError(
@@ -978,4 +978,3 @@ class KATCPReply(_KATCPReplyTuple):
     def succeeded(self):
         """True if request succeeded (i.e. first reply argument is 'ok')."""
         return bool(self)
-

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -55,6 +55,23 @@ def transform_future(transformation, future):
     future.add_done_callback(_transform)
     return new_future
 
+def until_all(futures):
+    """Run multiple operations in parallel but only raise a single TimeoutError.
+
+    This returns a yieldable object that will contain the results of `futures`
+    in an equivalent container (list or dict). However, it only raises the
+    first TimeoutError and ignores any further timeouts. This makes it useful
+    to wait on the results of multiple operations with the same timeout, as the
+    first occurrence of a timeout means that any unresolved futures will also
+    necessarily time out, leading to a rash of duplicate exceptions otherwise.
+
+    The function name implies kinship with :func:`katcp.core.until_any`.
+    The primary difference is that `until_any` takes an explicit timeout while
+    this function relies on the individual futures to have their own timeouts.
+
+    """
+    return tornado.gen.multi(futures, quiet_exceptions=tornado.gen.TimeoutError)
+
 @tornado.gen.coroutine
 def list_sensors(parent_class, sensor_items, filter, strategy, status,
                  use_python_identifiers, tuple, refresh):
@@ -1093,12 +1110,14 @@ class ClientGroup(object):
         present
 
         """
-        wait_result_futures = {}
+        # Build dict of futures instead of list as this will be easier to debug
+        futures = {}
         for client in self.clients:
-            wait_result_futures[client.name] = client.wait(
-                sensor_name, condition_or_value, status, timeout)
-        wait_results = yield wait_result_futures
-        raise tornado.gen.Return(all(wait_results.values()))
+            futures[client.name] = client.wait(sensor_name, condition_or_value,
+                                               status, timeout)
+        results = yield until_all(futures)
+        raise tornado.gen.Return(all(results.values()))
+
 
 class KATCPClientResourceContainer(resource.KATCPResource):
     """Class for containing multiple :class:`KATCPClientResource` instances
@@ -1253,7 +1272,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
     def until_synced(self, timeout=None):
         """Return a tornado Future; resolves when all subordinate clients are synced"""
         futures = [r.until_synced(timeout) for r in dict.values(self.children)]
-        yield tornado.gen.multi(futures, quiet_exceptions=tornado.gen.TimeoutError)
+        yield until_all(futures)
 
     @tornado.gen.coroutine
     def until_not_synced(self, timeout=None):
@@ -1271,7 +1290,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
         """Return a tornado Future; resolves when all clients are in specified state"""
         futures = [r.until_state(state, timeout=timeout)
                    for r in dict.values(self.children)]
-        yield tornado.gen.multi(futures, quiet_exceptions=tornado.gen.TimeoutError)
+        yield until_all(futures)
 
     @steal_docstring_from(resource.KATCPResource.list_sensors)
     def list_sensors(self, filter="", strategy=False, status="",

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1078,8 +1078,7 @@ class ClientGroup(object):
 
     @tornado.gen.coroutine
     def wait(self, sensor_name, condition_or_value, status=None, timeout=5):
-        """Wait for a sensor present on all clients in the group to satisfy a
-        condition.
+        """Wait for sensor present on all group clients to satisfy a condition.
 
         Parameters
         ----------
@@ -1095,19 +1094,21 @@ class ClientGroup(object):
             Wait for this status, at the same time as value above, to be
             obtained. Ignore status if None
         timeout : float or None
-            The timeout in seconds
+            The timeout in seconds (None means wait forever)
 
         Returns
         -------
-        This command returns a tornado Future that resolves with True if the
-        sensor values satisifed the condition with the timeout, else resolves
-        with False.
+        This command returns a tornado Future that resolves with True when all
+        sensor values satisfy the condition. It will never resolve with False;
+        if a timeout is given a TimeoutError happens instead.
 
         Raises
         ------
-        Resolves with a :class:`KATCPSensorError` exception if any of the
-        sensors do not have a strategy set, or if the named sensor is not
-        present
+        :class:`KATCPSensorError`
+            If any of the sensors do not have a strategy set, or if the named
+            sensor is not present
+        :class:`tornado.gen.TimeoutError`
+            If any sensor condition still fails after a stated timeout period
 
         """
         # Build dict of futures instead of list as this will be easier to debug

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1068,6 +1068,30 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         self.assertIs(DUT.req.resource3_halt,
                       DUT.children['resource3'].req.halt)
 
+    @tornado.testing.gen_test(timeout=1)
+    def test_group_wait(self):
+        # Start new container
+        self.default_spec_orig = copy.deepcopy(self.default_spec)
+        DUT = resource_client.KATCPClientResourceContainer(self.default_spec)
+        DUT.add_group('test', DUT.children.keys())
+        DUT.start()
+        # Setup a new sensor on all clients to wait on
+        wait_sensor = DeviceTestSensor(DeviceTestSensor.INTEGER, 'wait_sensor',
+                                       "An Integer.",
+                                       "count", [-50, 50], timestamp=self.io_loop.time(),
+                                       status=DeviceTestSensor.NOMINAL, value=0)
+        for server in self.servers.values():
+            server.add_sensor(wait_sensor)
+        yield DUT.until_synced()
+        # Ensure strategies are set for wait() to work
+        for client in DUT.children.values():
+            client.set_sampling_strategy('wait_sensor', 'event')
+        group = DUT.groups['test']
+        result = yield group.wait('wait_sensor', 0, timeout=0.5)
+        self.assertEqual(result, True)
+        with self.assertRaises(tornado.gen.TimeoutError):
+            yield group.wait('wait_sensor', 1, timeout=0.5)
+
 
 class test_ThreadsafeMethodAttrWrapper(unittest.TestCase):
     def setUp(self):

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1087,7 +1087,7 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         for client in DUT.children.values():
             client.set_sampling_strategy('wait_sensor', 'event')
         group = DUT.groups['test']
-        result = yield group.wait('wait_sensor', 0, timeout=0.5)
+        result = yield group.wait('wait_sensor', 0, timeout=None)
         self.assertEqual(result, True)
         with self.assertRaises(tornado.gen.TimeoutError):
             yield group.wait('wait_sensor', 1, timeout=0.5)


### PR DESCRIPTION
Multiple TimeoutErrors are potentially raised when waiting on multiple futures
with their own (equal) timeouts, leading to messy error messages. Clean this
up by using tornado.gen.multi with the appropriate exception quieting.

Since this trick is already in use in the module, put it in a separate
helper function. The name is chosen to indicate kinship with 'until_any'
although the API is slightly different (i.e. timeouts are delegated to
individual futures).

Also improve the docs around timeouts.
