### PR TITLE
Simplify sensor wait() interface

### DIFF
--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -857,7 +857,7 @@ class KATCPSensor(object):
             condition is satisfied. Since the reading is passed in, the value,
             status, timestamp or received_timestamp attributes can all be used
             in the check.
-            TODO: Sequences of conditions (use SensorTranstionWaiter thingum?)
+            TODO: Sequences of conditions (use SensorTransitionWaiter thingum?)
         timeout : float or None
             The timeout in seconds (None means wait forever)
 

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -200,16 +200,14 @@ class KATCPResource(object):
         Returns
         -------
         This command returns a tornado Future that resolves with True when the
-        sensor value satisfies the condition. It will never resolve with False;
-        if a timeout is given a TimeoutError happens instead.
+        sensor value satisfies the condition, or False if the condition is
+        still not satisfied after a given timeout period.
 
         Raises
         ------
         :class:`KATCPSensorError`
             If the sensor does not have a strategy set, or if the named sensor
             is not present
-        :class:`tornado.gen.TimeoutError`
-            If the sensor condition still fails after a stated timeout period
 
         """
         sensor_name = escape_name(sensor_name)

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -197,18 +197,21 @@ class KATCPResource(object):
             Wait for this status, at the same time as value above, to be
             obtained. Ignore status if None
         timeout : float or None
-            The timeout in seconds
+            The timeout in seconds (None means wait forever)
 
         Returns
         -------
-        This command returns a tornado Future that resolves with True if the
-        sensor values satisifed the condition with the timeout, else resolves
-        with False.
+        This command returns a tornado Future that resolves with True when the
+        sensor value satisfies the condition. It will never resolve with False;
+        if a timeout is given a TimeoutError happens instead.
 
         Raises
         ------
-        Resolves with a :class:`KATCPSensorError` exception if the sensors does
-        not have a strategy set.
+        :class:`KATCPSensorError`
+            If the sensor does not have a strategy set, or if the named sensor
+            is not present
+        :class:`tornado.gen.TimeoutError`
+            If the sensor condition still fails after a stated timeout period
 
         """
         sensor_name = escape_name(sensor_name)
@@ -843,7 +846,7 @@ class KATCPSensor(object):
         raise Return(self._reading.status)
 
     def wait(self, condition_or_value, status=None, timeout=None):
-        """Wait for sensor to satisfy a condition.
+        """Wait for the sensor to satisfy a condition.
 
         Parameters
         ----------
@@ -853,30 +856,27 @@ class KATCPSensor(object):
             condition is satisfied. Since the reading is passed in, the value,
             status, timestamp or received_timestamp attributes can all be used
             in the check.
-
-            Sequences of conditions are TODO, use SensorTranstionWaiter thingum?
+            TODO: Sequences of conditions (use SensorTranstionWaiter thingum?)
         status : int enum, key of katcp.Sensor.SENSOR_TYPES or None
             Wait for this status, at the same time as value above, to be
             obtained. Ignore status if None
         timeout : float or None
-            The timeout in seconds
+            The timeout in seconds (None means wait forever)
 
         Returns
         -------
-        This command returns a tornado Future that resolves with True if the
-        sensor values satisifed the condition with the timeout, else resolves
-        with False.
+        This command returns a tornado Future that resolves with True when the
+        sensor value satisfies the condition. It will never resolve with False;
+        if a timeout is given a TimeoutError happens instead.
 
         Raises
         ------
-        Resolves with a :class:`KATCPSensorError` exception if the sensors does
-        not have a strategy set.
-
-        Resolves with :class:`tornado.gen.TimeoutError` if timeout is not None
-        and the sensor does not attain the requested value within the timeout.
+        :class:`KATCPSensorError`
+            If the sensor does not have a strategy set
+        :class:`tornado.gen.TimeoutError`
+            If the sensor condition still fails after a stated timeout period
 
         """
-
         if (isinstance(condition_or_value, collections.Sequence) and not
                 isinstance(condition_or_value, basestring)):
             raise NotImplementedError(
@@ -978,4 +978,3 @@ class KATCPReply(_KATCPReplyTuple):
     def succeeded(self):
         """True if request succeeded (i.e. first reply argument is 'ok')."""
         return bool(self)
-

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -55,6 +55,23 @@ def transform_future(transformation, future):
     future.add_done_callback(_transform)
     return new_future
 
+def until_all(futures):
+    """Run multiple operations in parallel but only raise a single TimeoutError.
+
+    This returns a yieldable object that will contain the results of `futures`
+    in an equivalent container (list or dict). However, it only raises the
+    first TimeoutError and ignores any further timeouts. This makes it useful
+    to wait on the results of multiple operations with the same timeout, as the
+    first occurrence of a timeout means that any unresolved futures will also
+    necessarily time out, leading to a rash of duplicate exceptions otherwise.
+
+    The function name implies kinship with :func:`katcp.core.until_any`.
+    The primary difference is that `until_any` takes an explicit timeout while
+    this function relies on the individual futures to have their own timeouts.
+
+    """
+    return tornado.gen.multi(futures, quiet_exceptions=tornado.gen.TimeoutError)
+
 @tornado.gen.coroutine
 def list_sensors(parent_class, sensor_items, filter, strategy, status,
                  use_python_identifiers, tuple, refresh):
@@ -1093,12 +1110,14 @@ class ClientGroup(object):
         present
 
         """
-        wait_result_futures = {}
+        # Build dict of futures instead of list as this will be easier to debug
+        futures = {}
         for client in self.clients:
-            wait_result_futures[client.name] = client.wait(
-                sensor_name, condition_or_value, status, timeout)
-        wait_results = yield wait_result_futures
-        raise tornado.gen.Return(all(wait_results.values()))
+            futures[client.name] = client.wait(sensor_name, condition_or_value,
+                                               status, timeout)
+        results = yield until_all(futures)
+        raise tornado.gen.Return(all(results.values()))
+
 
 class KATCPClientResourceContainer(resource.KATCPResource):
     """Class for containing multiple :class:`KATCPClientResource` instances
@@ -1253,7 +1272,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
     def until_synced(self, timeout=None):
         """Return a tornado Future; resolves when all subordinate clients are synced"""
         futures = [r.until_synced(timeout) for r in dict.values(self.children)]
-        yield tornado.gen.multi(futures, quiet_exceptions=tornado.gen.TimeoutError)
+        yield until_all(futures)
 
     @tornado.gen.coroutine
     def until_not_synced(self, timeout=None):
@@ -1271,7 +1290,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
         """Return a tornado Future; resolves when all clients are in specified state"""
         futures = [r.until_state(state, timeout=timeout)
                    for r in dict.values(self.children)]
-        yield tornado.gen.multi(futures, quiet_exceptions=tornado.gen.TimeoutError)
+        yield until_all(futures)
 
     @steal_docstring_from(resource.KATCPResource.list_sensors)
     def list_sensors(self, filter="", strategy=False, status="",

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1078,8 +1078,7 @@ class ClientGroup(object):
 
     @tornado.gen.coroutine
     def wait(self, sensor_name, condition_or_value, status=None, timeout=5):
-        """Wait for a sensor present on all clients in the group to satisfy a
-        condition.
+        """Wait for sensor present on all group clients to satisfy a condition.
 
         Parameters
         ----------
@@ -1095,19 +1094,21 @@ class ClientGroup(object):
             Wait for this status, at the same time as value above, to be
             obtained. Ignore status if None
         timeout : float or None
-            The timeout in seconds
+            The timeout in seconds (None means wait forever)
 
         Returns
         -------
-        This command returns a tornado Future that resolves with True if the
-        sensor values satisifed the condition with the timeout, else resolves
-        with False.
+        This command returns a tornado Future that resolves with True when all
+        sensor values satisfy the condition. It will never resolve with False;
+        if a timeout is given a TimeoutError happens instead.
 
         Raises
         ------
-        Resolves with a :class:`KATCPSensorError` exception if any of the
-        sensors do not have a strategy set, or if the named sensor is not
-        present
+        :class:`KATCPSensorError`
+            If any of the sensors do not have a strategy set, or if the named
+            sensor is not present
+        :class:`tornado.gen.TimeoutError`
+            If any sensor condition still fails after a stated timeout period
 
         """
         # Build dict of futures instead of list as this will be easier to debug

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -66,7 +66,7 @@ def until_all(futures):
     necessarily time out, leading to a rash of duplicate exceptions otherwise.
 
     The function name implies kinship with :func:`katcp.core.until_any`.
-    The primary difference is that `until_any` takes an explicit timeout while
+    Their interfaces differ in that `until_any` takes an explicit timeout while
     this function relies on the individual futures to have their own timeouts.
 
     """

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1077,7 +1077,7 @@ class ClientGroup(object):
         raise tornado.gen.Return(sensors_strategies)
 
     @tornado.gen.coroutine
-    def wait(self, sensor_name, condition_or_value, status=None, timeout=5):
+    def wait(self, sensor_name, condition_or_value, timeout=5):
         """Wait for sensor present on all group clients to satisfy a condition.
 
         Parameters
@@ -1090,9 +1090,6 @@ class ClientGroup(object):
             condition is satisfied. Since the reading is passed in, the value,
             status, timestamp or received_timestamp attributes can all be used
             in the check.
-        status : int enum, key of katcp.Sensor.SENSOR_TYPES or None
-            Wait for this status, at the same time as value above, to be
-            obtained. Ignore status if None
         timeout : float or None
             The timeout in seconds (None means wait forever)
 
@@ -1115,7 +1112,7 @@ class ClientGroup(object):
         futures = {}
         for client in self.clients:
             futures[client.name] = client.wait(sensor_name, condition_or_value,
-                                               status, timeout)
+                                               timeout)
         results = yield futures
         class TestableDict(dict):
             def __bool__(self):

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1116,7 +1116,7 @@ class ClientGroup(object):
         for client in self.clients:
             futures[client.name] = client.wait(sensor_name, condition_or_value,
                                                status, timeout)
-        results = yield until_all(futures)
+        results = yield futures
         raise tornado.gen.Return(all(results.values()))
 
 

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1117,7 +1117,12 @@ class ClientGroup(object):
             futures[client.name] = client.wait(sensor_name, condition_or_value,
                                                status, timeout)
         results = yield futures
-        raise tornado.gen.Return(all(results.values()))
+        class TestableDict(dict):
+            def __bool__(self):
+                return all(self.values())
+            def __nonzero__(self):
+                return self.__bool__()
+        raise tornado.gen.Return(TestableDict(results))
 
 
 class KATCPClientResourceContainer(resource.KATCPResource):

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1096,16 +1096,14 @@ class ClientGroup(object):
         Returns
         -------
         This command returns a tornado Future that resolves with True when all
-        sensor values satisfy the condition. It will never resolve with False;
-        if a timeout is given a TimeoutError happens instead.
+        sensor values satisfy the condition, or False if any sensor condition
+        is still not satisfied after a given timeout period.
 
         Raises
         ------
         :class:`KATCPSensorError`
             If any of the sensors do not have a strategy set, or if the named
             sensor is not present
-        :class:`tornado.gen.TimeoutError`
-            If any sensor condition still fails after a stated timeout period
 
         """
         # Build dict of futures instead of list as this will be easier to debug
@@ -1115,6 +1113,7 @@ class ClientGroup(object):
                                                timeout)
         results = yield futures
         class TestableDict(dict):
+            """Dictionary of results that can be tested for overall success."""
             def __bool__(self):
                 return all(self.values())
             def __nonzero__(self):
@@ -1423,7 +1422,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
                                        .format(child_name))
 
     @steal_docstring_from(resource.KATCPResource.wait)
-    def wait(self, sensor_name, condition, timeout=5):
+    def wait(self, sensor_name, condition_or_value, timeout=5):
         raise NotImplementedError
 
     def _child_add_requests(self, child, sensor_keys):

--- a/katcp/test/test_resource.py
+++ b/katcp/test/test_resource.py
@@ -94,8 +94,10 @@ class test_KATCPSensor(TimewarpAsyncTestCase):
         # wait for value and status
         waiting_value = 3
         waiting_status = 'warn'
+        waiting_condition = lambda reading: reading.value == waiting_value and \
+                                            reading.status == waiting_status
         self.io_loop.add_callback(DUT.set_value, 3, Sensor.WARN)
-        yield DUT.wait(waiting_value, waiting_status)
+        yield DUT.wait(waiting_condition, timeout=timeout)
         self.assertEqual(DUT.value, waiting_value)
         self.assertEqual(DUT.status, waiting_status)
         # Check that no stray listeners are left behind
@@ -130,4 +132,3 @@ class test_KATCPRequest(unittest.TestCase):
         rv = DUT(*req_args, **req_kwargs)
         self.assertEqual(rv, DUT.issue_request.return_value)
         DUT.issue_request.assert_called_once_with(*req_args, **req_kwargs)
-

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1090,6 +1090,7 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         # Test the no timeout case too for what it's worth
         result = yield group.wait('wait_sensor', 0, timeout=None)
         self.assertTrue(result)
+        # Check detailed results per client
         for client in DUT.children.values():
             self.assertTrue(result[client.name])
         result = yield group.wait('wait_sensor', 1, timeout=0.5)

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1068,6 +1068,30 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         self.assertIs(DUT.req.resource3_halt,
                       DUT.children['resource3'].req.halt)
 
+    @tornado.testing.gen_test(timeout=1)
+    def test_group_wait(self):
+        # Start new container
+        self.default_spec_orig = copy.deepcopy(self.default_spec)
+        DUT = resource_client.KATCPClientResourceContainer(self.default_spec)
+        DUT.add_group('test', DUT.children.keys())
+        DUT.start()
+        # Setup a new sensor on all clients to wait on
+        wait_sensor = DeviceTestSensor(DeviceTestSensor.INTEGER, 'wait_sensor',
+                                       "An Integer.",
+                                       "count", [-50, 50], timestamp=self.io_loop.time(),
+                                       status=DeviceTestSensor.NOMINAL, value=0)
+        for server in self.servers.values():
+            server.add_sensor(wait_sensor)
+        yield DUT.until_synced()
+        # Ensure strategies are set for wait() to work
+        for client in DUT.children.values():
+            client.set_sampling_strategy('wait_sensor', 'event')
+        group = DUT.groups['test']
+        result = yield group.wait('wait_sensor', 0, timeout=0.5)
+        self.assertEqual(result, True)
+        with self.assertRaises(tornado.gen.TimeoutError):
+            yield group.wait('wait_sensor', 1, timeout=0.5)
+
 
 class test_ThreadsafeMethodAttrWrapper(unittest.TestCase):
     def setUp(self):

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1087,10 +1087,11 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         for client in DUT.children.values():
             client.set_sampling_strategy('wait_sensor', 'event')
         group = DUT.groups['test']
+        # Test the no timeout case too for what it's worth
         result = yield group.wait('wait_sensor', 0, timeout=None)
         self.assertEqual(result, True)
-        with self.assertRaises(tornado.gen.TimeoutError):
-            yield group.wait('wait_sensor', 1, timeout=0.5)
+        result = yield group.wait('wait_sensor', 1, timeout=0.5)
+        self.assertEqual(result, False)
 
 
 class test_ThreadsafeMethodAttrWrapper(unittest.TestCase):

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1087,7 +1087,7 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         for client in DUT.children.values():
             client.set_sampling_strategy('wait_sensor', 'event')
         group = DUT.groups['test']
-        result = yield group.wait('wait_sensor', 0, timeout=0.5)
+        result = yield group.wait('wait_sensor', 0, timeout=None)
         self.assertEqual(result, True)
         with self.assertRaises(tornado.gen.TimeoutError):
             yield group.wait('wait_sensor', 1, timeout=0.5)

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1089,9 +1089,13 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         group = DUT.groups['test']
         # Test the no timeout case too for what it's worth
         result = yield group.wait('wait_sensor', 0, timeout=None)
-        self.assertEqual(result, True)
+        self.assertTrue(result)
+        for client in DUT.children.values():
+            self.assertTrue(result[client.name])
         result = yield group.wait('wait_sensor', 1, timeout=0.5)
-        self.assertEqual(result, False)
+        self.assertFalse(result)
+        for client in DUT.children.values():
+            self.assertFalse(result[client.name])
 
 
 class test_ThreadsafeMethodAttrWrapper(unittest.TestCase):


### PR DESCRIPTION
The current wait() machinery is unsatisfactory. If the sensor
meets the condition, wait() returns True. On the other hand,
if the sensor does not meet the condition before the timeout,
a TimeoutError is raised. Wait() never returns False, making
the whole thing quite asymmetric.

The TimeoutErrors currently cause observation scripts to
crash (mostly for no good reason). Catching the exception
within the observation framework is messy.

My proposal is to swallow the TimeoutError at the KATCPResource
level and turn it into a proper symmetric False return.
User-facing client and client group objects will therefore
never crash like this again.

In addition, the ClientGroup.wait now returns extra information
that allows the user to report back on which clients have failed
the sensor condition without re-evaluating those conditions.
Users who don't care about the extra info can still simply check
the truth value of the returned dict.

As a further minor niggle, the explicit status check is dropped
in favour of the existing sensor reading check that can handle
all cases of interest.

Since the session and observation scripts are the main users of
wait(), I don't foresee any issues with the API change. All scripts
in katsdpscripts master remain valid.

This addresses JIRA tickets [MKAIV-244](https://skaafrica.atlassian.net/browse/MKAIV-244), [MRTS-361](https://skaafrica.atlassian.net/browse/MRTS-361) and [MKAIV-126](https://skaafrica.atlassian.net/browse/MKAIV-126) and related ones (and also [KAT-1869](https://skaafrica.atlassian.net/browse/KAT-1869) to some extent).