### PR TITLE
CB-1320 - plug memory leak in KATCPClientResourceContainer

### DIFF
--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -164,9 +164,6 @@ class InspectingClientAsync(object):
                 connected=False, synced=False, model_changed=False, data_synced=False)
         )
 
-    def __del__(self):
-        self.close()
-
     def inform_hook_client_factory(self, host, port, *args, **kwargs):
         """Return an instance of :class:`_InformHookDeviceClient` or similar
 
@@ -353,7 +350,6 @@ class InspectingClientAsync(object):
 
     def close(self):
         self.stop()
-        self.join()
 
     def start(self, timeout=None):
         return self.connect(timeout)
@@ -361,6 +357,7 @@ class InspectingClientAsync(object):
     def stop(self, timeout=None):
         self._running = False
         self.katcp_client.stop(timeout)
+        self.join(timeout)
 
     def join(self, timeout=None):
         self.katcp_client.join(timeout)

--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -83,6 +83,9 @@ class InspectingClientAsync(object):
     Note: This class is not threadsafe at present, it should only be called
     from the ioloop.
 
+    Note: always call stop() after start() and you are done with the container
+    to make sure the container cleans up correctly.
+
     """
     sensor_factory = katcp.Sensor
     """Factory that produces a KATCP Sensor compatible instance.
@@ -352,12 +355,15 @@ class InspectingClientAsync(object):
         self.stop()
 
     def start(self, timeout=None):
+        """
+        Note: always call stop() when you are done with the container
+        to make sure the container cleans up correctly.
+        """
         return self.connect(timeout)
 
     def stop(self, timeout=None):
         self._running = False
         self.katcp_client.stop(timeout)
-        self.join(timeout)
 
     def join(self, timeout=None):
         self.katcp_client.join(timeout)


### PR DESCRIPTION
removed __del__ method that calls the join on katcp_client (which in turn calls join on the io_loop_manager's thread join) because it was causing a massive memory leak for anyone using the KATCPClientResourceContainer