### PR TITLE
Handle malformed log lines.

### DIFF
--- a/katcp/server.py
+++ b/katcp/server.py
@@ -2422,9 +2422,20 @@ class DeviceLogger(object):
             name = kwargs.get("name")
             if name is None:
                 name = self._root_logger_name
+            try:
+                inform_msg = msg % args
+            except TypeError:
+                # Catch the "not enough arguments for format string" exception.
+                inform_msg = "{} {}".format(
+                    msg,
+                    args if args else '').strip()
+
             self._device_server.mass_inform(
                 self._device_server.create_log_inform(
-                    self.level_name(level), msg % args, name, timestamp=timestamp))
+                    self.level_name(level),
+                    inform_msg,
+                    name,
+                    timestamp=timestamp))
 
     def trace(self, msg, *args, **kwargs):
         """Log a trace message."""


### PR DESCRIPTION
With this change the log method is a bit more robust. We see log messages with the "%s" string in them, an upstream error. These log messages causes KATCP to throw a stack trace and in the process shadow the real error.

I wonder if we should cleanup the log message, or alert the user that it was malformed.
e.g. Maybe this would be better. What do you think?
```
               inform_msg = "(malformed log message) {} {}".format(
                     msg.replace("%s", "?"),
                     args if args else '').strip(' ?')
```
