### PR TITLE
Make parsing of int's safer, can now handle a float string.

### DIFF
--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -158,7 +158,7 @@ class Int(KatcpType):
 
     def decode(self, value, major):
         try:
-            return int(value)
+            return int(float(value))
         except:
             raise ValueError("Could not parse value '%s' as integer." % value)
 
@@ -293,7 +293,7 @@ class Lru(KatcpType):
     # LRU sensor values
     LRU_NOMINAL, LRU_ERROR = range(2)
 
-    ## @brief Mapping from LRU value constant to LRU value name.
+    # @brief Mapping from LRU value constant to LRU value name.
     LRU_VALUES = {
         LRU_NOMINAL: "nominal",
         LRU_ERROR: "error",
@@ -302,7 +302,7 @@ class Lru(KatcpType):
     # LRU_VALUES not found by pylint
     # pylint: disable-msg = E0602
 
-    ## @brief Mapping from LRU value name to LRU value constant.
+    # @brief Mapping from LRU value name to LRU value constant.
     LRU_CONSTANTS = dict((v, k) for k, v in LRU_VALUES.items())
 
     def encode(self, value, major):

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -13,6 +13,7 @@ import re
 import logging
 
 from functools import partial
+from decimal import Decimal
 
 from tornado import gen
 
@@ -158,7 +159,10 @@ class Int(KatcpType):
 
     def decode(self, value, major):
         try:
-            return int(float(value))
+            try:
+                return int(value)
+            except ValueError:
+                return int(Decimal(value))
         except:
             raise ValueError("Could not parse value '%s' as integer." % value)
 

--- a/katcp/test/test_kattypes.py
+++ b/katcp/test/test_kattypes.py
@@ -61,9 +61,11 @@ class TestInt(TestType):
             (optional, None, ValueError),
         ]
 
+        bint = int('5' * 60)
         self._unpack = [
             (basic, "5", 5),
             (basic, "-5", -5),
+            (basic, str(bint) + ".22222", bint),
             (basic, "a", ValueError),
             (basic, None, ValueError),
             (self.minmax, "5", 5),


### PR DESCRIPTION
We see that at times floating point strings are given to the Int sensor. To make the decoding more robust, cast it as float then as string. 
