### PR TITLE
Properly handle errors during inspection in inspecting client

### DIFF
--- a/katcp/client.py
+++ b/katcp/client.py
@@ -396,7 +396,9 @@ class DeviceClient(object):
         assert get_thread_ident() == self.ioloop_thread_id
         data = str(msg) + "\n"
         # Log all sent messages here so no one else has to.
-        self._logger.debug(repr(data))
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug("Sending to {}: {}"
+                               .format(self.bind_address_string, repr(data)))
         if not self._connected.isSet():
             raise KatcpClientDisconnected('Not connected to device {0}'.format(
                 self.bind_address_string))
@@ -509,7 +511,9 @@ class DeviceClient(object):
         """
         # log messages received so that no one else has to
         if self._logger.isEnabledFor(logging.DEBUG):
-            self._logger.debug(repr(str(msg)))
+            self._logger.debug(
+                "received from {}: {}"
+                .format(self.bind_address_string, repr(str(msg))))
 
         if msg.mtype == Message.INFORM:
             return self.handle_inform(msg)

--- a/katcp/core.py
+++ b/katcp/core.py
@@ -64,11 +64,11 @@ def log_coroutine_exceptions(coro):
 
     import logging
 
-    @log_coroutine_exceptions
-    @tornado.gen.coroutine
     class A(object):
         _logger = logging.getLogger(__name__)
 
+        @log_coroutine_exceptions
+        @tornado.gen.coroutine
         def raiser(self, arg):
             yield tornado.gen.moment
             raise Exception(arg)

--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -372,7 +372,6 @@ class InspectingClientAsync(object):
                         continue
                     model_changes = yield self.inspect()
                     model_changed = bool(model_changes)
-                    synced = not model_changed
                     yield self._send_state(
                         connected=True, synced=False,
                         model_changed=model_changed, data_synced=True,
@@ -475,6 +474,7 @@ class InspectingClientAsync(object):
 
     @tornado.gen.coroutine
     def inspect(self):
+        """Inspect device requests and sensors, update model"""
         timeout_manager = future_timeout_manager(self.sync_timeout)
         request_changes = yield self.inspect_requests(timeout=timeout_manager.remaining())
         sensor_changes = yield self.inspect_sensors(timeout=timeout_manager.remaining())
@@ -489,7 +489,7 @@ class InspectingClientAsync(object):
 
     @tornado.gen.coroutine
     def inspect_requests(self, name=None, timeout=None):
-        """Inspect all or one requests on the device.
+        """Inspect all or one requests on the device. Update requests index.
 
         Parameters
         ----------
@@ -530,7 +530,7 @@ class InspectingClientAsync(object):
 
     @tornado.gen.coroutine
     def inspect_sensors(self, name=None, timeout=None):
-        """Inspect all or one sensor on the device.
+        """Inspect all or one sensor on the device. Update sensors index.
 
         Parameters
         ----------

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -399,7 +399,8 @@ class KATCPClientResource(resource.KATCPResource):
         ic.katcp_client.auto_reconnect_delay = self.auto_reconnect_delay
         ic.set_state_callback(self._inspecting_client_state_callback)
         ic.request_factory = self._request_factory
-        self._sensor_manager = KATCPClientResourceSensorsManager(ic, self.name, logger=self._logger)
+        self._sensor_manager = KATCPClientResourceSensorsManager(
+            ic, self.name, logger=self._logger)
         ic.handle_sensor_value()
         ic.sensor_factory = self._sensor_manager.sensor_factory
 

--- a/katcp/test/test_inspectclient.py
+++ b/katcp/test/test_inspectclient.py
@@ -38,8 +38,14 @@ class TestExponentialRandomBackoff(unittest.TestCase):
 
             # Do several more failures
             [DUT.failed() for x in range(5)]
+            # Check that the delay does not grow beyond the maximum expected
+            # value
             max_expected_delay = (1-r)*dm + r*dm*rv
-            self.assertEqual(DUT.delay, max_expected_delay)
+            self.assertAlmostEqual(DUT.delay, max_expected_delay)
+
+            # Test that DUT.success() resets the delay
+            DUT.success()
+            self.assertEqual(DUT.delay, first_delay)
 
 
 class TestICAClass(tornado.testing.AsyncTestCase):
@@ -391,7 +397,7 @@ class TestInspectingClientAsyncStateCallback(tornado.testing.AsyncTestCase):
         self.assertIs(model_changes, None)
         # Due to the structure of the state loop the initial state may be sent
         # twice before we get here, and was the case for the initial
-        # implementation. Changes made on 2015-01-26 caused it to happy only
+        # implementation. Changes made on 2015-01-26 caused it to happen only
         # once, hence + 1. If the implementation changes having + 2 would also
         # be OK.
         yield self._check_no_cb(num_calls_before + 1)


### PR DESCRIPTION
On the dev32 system the single process that is trying to connect and sync to all 32
dishes takes too long, resulting in some of the inspection requests timing
out. InspectingClient was ignoring these errors, resulting in a client that says
it is synced, but does not properly reflect its server's state

Also added a random-exponential retry backoff process to ensure that the
thundering herd does not continue thundering