### PR TITLE
Remove spurious KeyboardInterrupt catch in IOLoopThreadWrapper

### DIFF
--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1473,13 +1473,9 @@ class IOLoopThreadWrapper(object):
             return future.result(timeout)
         except TimeoutError:
             raise
-        except KeyboardInterrupt:
-            print('=== KeyboardInterrupt ===')
-            sys.exc_clear()
-
         except Exception:
-            # If we have an exception use the tornado future instead since it will print a
-            # nicer traceback.
+            # If we have an exception use the tornado future instead since it
+            # will print a nicer traceback.
             tornado_future.result()
             # Should never get here since the tornado future should raise
             assert False, 'Tornado Future should have raised'


### PR DESCRIPTION
Catching it there serves no purpose. The only way that
`future.result(timeout)` can raise a KeyboardInterrupt is if the main
thread is waiting on a future running on the ioloop in another thread.
If SIGINT is received, the KeyboardInterrupt should indeed propagate.