### PR TITLE
Add timeout hint protocol flag CB-569

### DIFF
--- a/katcp/core.py
+++ b/katcp/core.py
@@ -596,6 +596,9 @@ class ProtocolFlags(object):
 
     MULTI_CLIENT = 'M'
     MESSAGE_IDS = 'I'
+    # New proposal flag to indicate that a device supports ?request-timeout-hint
+    # See CB-2051
+    REQUEST_TIMEOUT_HINTS = 'T'
 
     STRATEGIES_V4 = frozenset(['none', 'auto', 'period', 'event',
                                'differential'])
@@ -607,15 +610,24 @@ class ProtocolFlags(object):
         5: STRATEGIES_V5
         }
 
+    REQUEST_TIMEOUT_HINTS_MIN_VERSION = (5, 1)
+
     def __init__(self, major, minor, flags):
         self.major = major
         self.minor = minor
         self.flags = set(list(flags))
         self.multi_client = self.MULTI_CLIENT in self.flags
         self.message_ids = self.MESSAGE_IDS in self.flags
+        self.request_timeout_hints = self.REQUEST_TIMEOUT_HINTS in self.flags
         if self.message_ids and self.major < MID_KATCP_MAJOR:
             raise ValueError(
                 'MESSAGE_IDS is only supported in katcp v5 and newer')
+        version_supports_hints = ((self.major, self.minor) >=
+                                  self.REQUEST_TIMEOUT_HINTS_MIN_VERSION)
+        if self.request_timeout_hints and not version_supports_hints:
+            raise ValueError(
+                'REQUEST_TIMEOUT_HINTS only suported in katcp v{}.{} and newer'
+                .format(self.major, self.minor))
 
     def strategy_allowed(self, strategy):
         return strategy in self.STRATEGIES_ALLOWED_BY_MAJOR_VERSION[self.major]

--- a/katcp/core.py
+++ b/katcp/core.py
@@ -628,7 +628,7 @@ class ProtocolFlags(object):
         if self.request_timeout_hints and not version_supports_hints:
             raise ValueError(
                 'REQUEST_TIMEOUT_HINTS only suported in katcp v{}.{} and newer'
-                .format(self.major, self.minor))
+                .format(*self.REQUEST_TIMEOUT_HINTS_MIN_VERSION))
 
     def strategy_allowed(self, strategy):
         return strategy in self.STRATEGIES_ALLOWED_BY_MAJOR_VERSION[self.major]

--- a/katcp/core.py
+++ b/katcp/core.py
@@ -736,10 +736,7 @@ class DeviceServerMetaclass(DeviceMetaclass):
         True if the current server's protocol flags satisfy handler requirements
 
         """
-        try:
-            protocol_info = mcs.PROTOCOL_INFO
-        except Exception:
-            import pdb ; pdb.set_trace()
+        protocol_info = mcs.PROTOCOL_INFO
         protocol_version = (protocol_info.major, protocol_info.minor)
         protocol_flags = protocol_info.flags
 

--- a/katcp/core.py
+++ b/katcp/core.py
@@ -569,6 +569,7 @@ class ProtocolFlags(object):
 
     * M - server supports multiple clients
     * I - server supports message identifiers
+    * T - server provides request timeout hints via ?request-timeout-hint
 
     Parameters
     ----------

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -1021,7 +1021,7 @@ def has_katcp_protocol_flags(protocol_flags):
     return decorator
 
 def request_timeout_hint(timeout_hint):
-    """Add recommended client timeout hint to a request for request
+    """Decorator; add recommended client timeout hint to a request for request
 
     Useful for requests that take longer than average to reply. Hint is provided
     to clients via ?request-timeout-hint. Note this is only exposed if the
@@ -1031,13 +1031,15 @@ def request_timeout_hint(timeout_hint):
     Parameters
     ----------
     timeout_hint : float (seconds) or None
-        How long the decorated request should reasonably take to reply
+        How long the decorated request should reasonably take to reply. No
+        timeout hint if None, similar to never using the decorator, provided for
+        consistency.
 
     Examples
     --------
     >>> class MyDevice(DeviceServer):
     ...     @return_reply(Int())
-    ...     @request_timeout_hint
+    ...     @request_timeout_hint(15) # Set request timeout hint to 15 seconds
     ...     @tornado.gen.coroutine
     ...     def request_myreq(self, req):
     ...         '''A slow request'''

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -947,6 +947,7 @@ def concurrent_reply(handler):
     ...     @concurrent_reply
     ...     @tornado.gen.coroutine
     ...     def request_myreq(self, req):
+    ...         '''A slow request'''
     ...         result = yield self.slow_operation()
     ...         raise tornado.gen.Return((req, result))
     ...
@@ -955,6 +956,69 @@ def concurrent_reply(handler):
 
     handler._concurrent_reply = True
     return handler
+
+def minimum_katcp_version(major, minor=0):
+    """Decorator; exclude handler if server's protocol version is too low
+
+    Useful for including default handler implementations for KATCP features that
+    are only present in certain KATCP protocol versions
+
+    Examples
+    --------
+    >>> class MyDevice(DeviceServer):
+    ...     '''This device server will expose ?myreq'''
+    ...     PROTOCOL_INFO = katcp.core.ProtocolFlags(5, 1)
+    ...
+    ...     @minimum_katcp_version(5, 1)
+    ...     def request_myreq(self, req, msg):
+    ...         '''A request that should only be present for KATCP >v5.1'''
+    ...         # Request handler implementation here.
+    ...
+    >>> class MyOldDevice(MyDevice):
+    ...     '''This device server will not expose ?myreq'''
+    ...
+    ...     PROTOCOL_INFO = katcp.core.ProtocolFlags(5, 0)
+    ...
+
+    """
+
+    version_tuple = (major, minor)
+    def decorator(handler):
+        handler._minimum_katcp_version = version_tuple
+        return handler
+
+    return decorator
+
+def has_katcp_protocol_flags(protocol_flags):
+    """Decorator; only include handler if server has these protocol flags
+
+    Useful for including default handler implementations for KATCP features that
+    are only present when certain server protocol flags are set.
+
+    Examples
+    --------
+    >>> class MyDevice(DeviceServer):
+    ...     '''This device server will expose ?myreq'''
+    ...     PROTOCOL_INFO = katcp.core.ProtocolFlags(5, 0, [
+                        katcp.core.ProtocolFlags.MULTI_CLIENT])
+    ...
+    ...     @has_katcp_protocol_flags([katcp.core.ProtocolFlags.MULTI_CLIENT])
+    ...     def request_myreq(self, req, msg):
+    ...         '''A request that requires multi-client support'''
+    ...         # Request handler implementation here.
+    ...
+    >>> class MySingleClientDevice(MyDevice):
+    ...     '''This device server will not expose ?myreq'''
+    ...
+    ...     PROTOCOL_INFO = katcp.core.ProtocolFlags(5, 0, [])
+    ...
+
+    """
+    def decorator(handler):
+        handler._has_katcp_protocol_flags = protocol_flags
+        return handler
+
+    return decorator
 
 @gen.coroutine
 def async_make_reply(msgname, types, arguments_future, major):

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -1020,6 +1020,41 @@ def has_katcp_protocol_flags(protocol_flags):
 
     return decorator
 
+def request_timeout_hint(timeout_hint):
+    """Add recommended client timeout hint to a request for request
+
+    Useful for requests that take longer than average to reply. Hint is provided
+    to clients via ?request-timeout-hint. Note this is only exposed if the
+    device server sets the protocol version to KATCP v5.1 or higher and enables
+    the REQUEST_TIMEOUT_HINTS flag in its PROTOCOL_INFO class attribute
+
+    Parameters
+    ----------
+    timeout_hint : float (seconds) or None
+        How long the decorated request should reasonably take to reply
+
+    Examples
+    --------
+    >>> class MyDevice(DeviceServer):
+    ...     @return_reply(Int())
+    ...     @request_timeout_hint
+    ...     @tornado.gen.coroutine
+    ...     def request_myreq(self, req):
+    ...         '''A slow request'''
+    ...         result = yield self.slow_operation()
+    ...         raise tornado.gen.Return((req, result))
+    ...
+
+    """
+    if timeout_hint is not None:
+        timeout_hint = float(timeout_hint)
+
+    def decorator(handler):
+        handler.request_timeout_hint = timeout_hint
+        return handler
+
+    return decorator
+
 @gen.coroutine
 def async_make_reply(msgname, types, arguments_future, major):
     """Wrap future that will resolve with arguments needed by make_reply()."""

--- a/katcp/server.py
+++ b/katcp/server.py
@@ -28,7 +28,7 @@ from tornado.util import ObjectDict
 from concurrent.futures import Future
 
 from .ioloop_manager import IOLoopManager, with_relative_timeout
-from .core import (DeviceMetaclass, Message, MessageParser,
+from .core import (DeviceServerMetaclass, Message, MessageParser,
                    FailReply, AsyncReply, ProtocolFlags)
 from .sampling import SampleStrategy, SampleNone
 from .sampling import format_inform_v5, format_inform_v4
@@ -938,7 +938,7 @@ class DeviceServerBase(object):
 
     """
 
-    __metaclass__ = DeviceMetaclass
+    __metaclass__ = DeviceServerMetaclass
 
     ## @brief Protocol versions and flags. Default to version 5, subclasses
     ## should override PROTOCOL_INFO

--- a/katcp/server.py
+++ b/katcp/server.py
@@ -34,7 +34,10 @@ from .sampling import SampleStrategy, SampleNone
 from .sampling import format_inform_v5, format_inform_v4
 from .core import (SEC_TO_MS_FAC, MS_TO_SEC_FAC, SEC_TS_KATCP_MAJOR,
                    VERSION_CONNECT_KATCP_MAJOR, DEFAULT_KATCP_MAJOR)
-from .kattypes import (request, return_reply)
+from .kattypes import (request, return_reply,
+                       minimum_katcp_version,
+                       has_katcp_protocol_flags,
+                       Int, Str)
 
 # 'import katcp' so that we can use katcp.__version__ later
 # we cannot do this: 'from . import __version__' because __version__
@@ -1813,6 +1816,81 @@ class DeviceServer(DeviceServerBase):
                 return req.make_reply("ok", "1")
             return req.make_reply("fail", "Unknown request method.")
 
+    @request(Str(optional=True))
+    @return_reply(Int())
+    @has_katcp_protocol_flags(ProtocolFlags.REQUEST_TIMEOUT_HINTS)
+    def request_request_timeout_hint(self, req, request):
+        """Return timeout hints for requests
+
+        KATCP requests should generally take less than 5s to complete, but some
+        requests are unavoidably slow. This results in spurious client timeout
+        errors. This request provides timeout hints that clients can use to
+        select suitable request timeouts.
+
+        Parameters
+        ----------
+        request : str, optional
+            The name of the request to return a timeout hint for (the default is
+            to return hints for all requests that have timeout hints). Returns
+            one inform per request. Must be an existing request if specified.
+
+        Informs
+        -------
+        request : str
+            The name of the request.
+        suggested_timeout : float
+            Suggested request timeout in seconds for the request. If
+            `suggested_timeout` is zero (0), no timeout hint is available.
+
+        Returns
+        -------
+        success : {'ok', 'fail'}
+            Whether sending the help succeeded.
+        informs : int
+            Number of #request-timeout-hint inform messages sent.
+
+        Examples
+        --------
+        ::
+
+            ?request-timeout-hint
+            #request-timeout-hint halt 5
+            #request-timeout-hint very-slow-request 500
+            ...
+            !request-timeout-hint ok 5
+
+            ?request-timeout-hint moderately-slow-request
+            #request-timeout-hint moderately-slow-request 20
+            !request-timeout-hint ok 1
+
+        Notes
+        -----
+
+        ?request-timeout-hint without a parameter will only return informs for
+        requests that have specific timeout hints, so it will most probably be a
+        subset of all the requests, or even no informs at all.
+
+        """
+        timeout_hints = {}
+        if request:
+            if request not in self._request_handlers:
+                raise FailReply('Unknown request method')
+            timeout_hint = getattr(
+                self._request_handlers[request], 'request_timeout_hint', None)
+            timeout_hint = timeout_hint or 0
+            timeout_hints[request] = timeout_hint
+        else:
+            for request_, handler in self._request_handlers.items():
+                timeout_hint = getattr(handler, 'request_timeout_hint', None)
+                if timeout_hint:
+                    timeout_hints[request_] = timeout_hint
+
+        cnt = len(timeout_hints)
+        for request_name, timeout_hint in sorted(timeout_hints.items()):
+            req.inform(request_name, float(timeout_hint))
+
+        return ('ok', cnt)
+
     def request_log_level(self, req, msg):
         """Query or set the current logging level.
 
@@ -1918,6 +1996,8 @@ class DeviceServer(DeviceServerBase):
             req.inform(addr)
         return req.make_reply('ok', str(num_clients))
 
+
+    @minimum_katcp_version(5, 0)
     def request_version_list(self, req, msg):
         """Request the list of versions of roles and subcomponents.
 

--- a/katcp/test/test_core.py
+++ b/katcp/test/test_core.py
@@ -174,6 +174,10 @@ class TestProtocolFlags(unittest.TestCase):
         # check an unknown flag
         self.assertEqual(PF.parse_version("5.1-MIU"),
                          PF(5, 1, set([PF.MULTI_CLIENT, PF.MESSAGE_IDS, 'U'])))
+        # Check request timeout hint flag
+        self.assertEqual(PF.parse_version("5.1-MTI"),
+                         PF(5, 1, set([PF.MULTI_CLIENT, PF.MESSAGE_IDS,
+                                       PF.REQUEST_TIMEOUT_HINTS])))
 
     def test_str(self):
         PF = katcp.ProtocolFlags
@@ -183,12 +187,21 @@ class TestProtocolFlags(unittest.TestCase):
         self.assertEqual(str(PF(5, 0, set([PF.MULTI_CLIENT, PF.MESSAGE_IDS,
                                            "U"]))),
                          "5.0-IMU")
+        self.assertEqual(str(PF(5, 1, set([PF.MULTI_CLIENT, PF.MESSAGE_IDS,
+                                           PF.REQUEST_TIMEOUT_HINTS]))),
+                         "5.1-IMT")
+
 
     def test_incompatible_options(self):
         PF = katcp.ProtocolFlags
         # Katcp v4 and below don't support message ids
         with self.assertRaises(ValueError):
             PF(4, 0, [PF.MESSAGE_IDS])
+
+        # Katcp v5 and below don't support (proposed) timeout hint flag
+        with self.assertRaises(ValueError):
+            PF(5, 0, [PF.REQUEST_TIMEOUT_HINTS])
+
 
 class TestSensor(unittest.TestCase):
 

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -290,8 +290,9 @@ katcp_version = __version__
 class test_DeviceServer(unittest.TestCase, TestUtilMixin):
 
     expected_connect_messages = (
+            # Will have to be updated if the default KATCP protocol
+            # spec version changes
             r'#version-connect katcp-protocol 5.0-IM',
-            # Will have to be updated for every library version bump
             r'#version-connect katcp-library katcp-python-%s' % katcp_version,
             r'#version-connect katcp-device deviceapi-5.6 buildy-1.2g')
 
@@ -359,7 +360,6 @@ class test_DeviceServer51(test_DeviceServer):
 
     expected_connect_messages = (
         r'#version-connect katcp-protocol 5.1-IMT',
-        # Will have to be updated for every library version bump
         r'#version-connect katcp-library katcp-python-%s' % katcp_version,
         r'#version-connect katcp-device deviceapi-5.6 buildy-1.2g')
 
@@ -395,7 +395,7 @@ class test_DeviceServer51(test_DeviceServer):
         self._assert_msgs_equal(req.inform_msgs,
                                 ['#request-timeout-hint help 0.0'])
 
-        # Now set hint on help command and check that it is reflected Note, in
+        # Now set hint on help command and check that it is reflected. Note, in
         # Python 3 the im_func would not be neccesary, but in Python 2 you
         # cannot add a new attribute to an instance method. For Python 2 we need
         # to make a copy of the original handler function using partial and then
@@ -1064,14 +1064,14 @@ class TestHandlerFiltering(unittest.TestCase):
                          expected_handlers)
         self.assertEqual(set(), actual_device_handlers & not_expected_handlers)
 
-
     def test_handler_protocol_filters_all(self):
         """Test handler filtering where everything should be included"""
         self._test_handler_protocol_filters(self.DeviceWithEverything,
                                             self.all_expected_handlers)
 
-    def test_handler_protocol_filters_five_with_nothing(self):
+    def test_handler_protocol_filters_five_one_with_nothing(self):
         """Test handler filtering where protocol flags exclude some"""
+
         class DeviceVersionFiveOneWithNothing(self.DeviceWithEverything):
             PROTOCOL_INFO = katcp.ProtocolFlags(5, 1, [])
 
@@ -1081,7 +1081,6 @@ class TestHandlerFiltering(unittest.TestCase):
 
     def test_handler_protocol_filters_five_one_with_multi(self):
         """Test handler filtering where protocol flags and version exclude some"""
-
 
         class DeviceVersionFiveOneWithMultiClient(self.DeviceWithEverything):
             PROTOCOL_INFO = katcp.ProtocolFlags(5, 1, [
@@ -1107,9 +1106,11 @@ class TestHandlerFiltering(unittest.TestCase):
 
     def test_handler_protocol_filters_four(self):
         """Test handler filtering for a KATCP v4.0 device"""
+
         class DeviceVersionFour(self.DeviceWithEverything):
             PROTOCOL_INFO = katcp.ProtocolFlags(
                 4, 0, [katcp.ProtocolFlags.MULTI_CLIENT])
+
         self._test_handler_protocol_filters(
             DeviceVersionFour, ['simple', 'fewer-flags'])
 

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -35,7 +35,8 @@ from .server import DeviceServer, FailReply, ClientConnection
 from .kattypes import (request,
                        return_reply,
                        Float,
-                       concurrent_reply)
+                       concurrent_reply,
+                       request_timeout_hint)
 
 
 logger = logging.getLogger(__name__)
@@ -1019,6 +1020,7 @@ class DeviceTestServer(DeviceServer):
         """A handler which raises a FailReply."""
         raise FailReply("There was a problem with your request.")
 
+    @request_timeout_hint(99)
     def request_slow_command(self, req, msg):
         """A slow command, waits for msg.arguments[0] seconds.
 
@@ -1104,6 +1106,7 @@ class AsyncDeviceTestServer(DeviceTestServer):
 
     @request(Float())
     @return_reply()
+    @request_timeout_hint(99)
     @concurrent_reply
     @gen.coroutine
     def request_slow_command(self, req, wait_time):


### PR DESCRIPTION
Idea is that we want a server to explicitly tell a client that it can use the ?request-timeout-hint request without the client having to guess.