### PR TITLE
Let resource client use timeout hints

### DIFF
--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -184,7 +184,8 @@ class InspectingClientAsync(object):
     request_factory = RequestType
     """Factory that produces KATCP Request objects
 
-    signature: request_factory(name, description')
+    signature: request_factory(name, description, timeout_hint), all parameters
+               passed as kwargs
 
     Should be set before calling connect()/start().
 
@@ -636,7 +637,8 @@ class InspectingClientAsync(object):
         requests_updated = set()
         for msg in informs:
             req_name = msg.arguments[0]
-            req = {'description': msg.arguments[1],
+            req = {'name': req_name,
+                   'description': msg.arguments[1],
                    'timeout_hint': timeout_hints.get(req_name)}
             requests_updated.add(req_name)
             self._update_index(self._requests_index, req_name, req)
@@ -901,8 +903,7 @@ class InspectingClientAsync(object):
             request_info = self._requests_index[name]
             obj = request_info.get('obj')
             if obj is None:
-                obj = self.request_factory(
-                    name, **request_info)
+                obj = self.request_factory(**request_info)
                 self._requests_index[name]['obj'] = obj
 
         raise tornado.gen.Return(obj)

--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -655,7 +655,7 @@ class InspectingClientAsync(object):
         Parameters
         =========
         name : str or None, optional
-            Name of the request or None to get all request  timeout hints.
+            Name of the request or None to get all request timeout hints.
         timeout : float seconds
             Timeout for ?request-timeout-hint
 

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -415,7 +415,7 @@ class KATCPRequest(object):
         -----------------
         timeout : None or float, optional
             Timeout in seconds for the request. If None, use request timeout
-            hint recieved from server or default for the :class:`KATCPResource`
+            hint received from server or default for the :class:`KATCPResource`
             instance that contains the request if no hint is available.
         mid : None or int, optional
             Message identifier to use for the request message. If None, use

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -337,8 +337,10 @@ class KATCPClientResource(resource.KATCPResource):
         self._sensor = AttrDict()
         self._dummy_unknown_requests = bool(resource_spec.get('dummy_unknown_requests'))
         if self._dummy_unknown_requests:
-            DummyRequest = partial(resource.KATCPDummyRequest,
-                                   'dummy', 'No help for dummies')
+            DummyRequest = partial(
+                resource.KATCPDummyRequest,
+                {'name':'dummy', 'description': 'No help for dummies',
+                 'timeout_hint': None})
             self._req = DefaultAttrDict(DummyRequest)
         else:
             self._req = AttrDict()
@@ -551,9 +553,9 @@ class KATCPClientResource(resource.KATCPResource):
         # Otherwise, depend on self._add_sensors() to handle it from the cache when the sensor appears
         raise tornado.gen.Return(sensor_dict)
 
-    def _request_factory(self, name, description, timeout_hint):
+    def _request_factory(self, **request_description):
         return KATCPClientResourceRequest(
-            name, description, self._inspecting_client, self.is_active)
+            request_description, self._inspecting_client, self.is_active)
 
     @tornado.gen.coroutine
     def _inspecting_client_state_callback(self, state, model_changes):
@@ -842,15 +844,14 @@ class KATCPClientResourceRequest(resource.KATCPRequest):
     """Callable wrapper around a KATCP request
 
     """
-    def __init__(self, name, description, client, is_active=lambda : True):
+    def __init__(self, request_description, client, is_active=lambda : True):
         """Initialize request with given description and network client
 
         Parameters
         ----------
-        name : str
-            KATCP name of the request
-        description : str
-            KATCP request description (as returned by ?help <name>)
+        request_description : dict
+            Description of KATCP request as required by
+            :class:`katcp.resource.KATCPRequest` init method
         client : client obj
             KATCP client connected to the KATCP resource that exposes a wrapped_request()
             method like :meth:`ReplyWrappedInspectingClientAsync.wrapped_request`.
@@ -859,7 +860,7 @@ class KATCPClientResourceRequest(resource.KATCPRequest):
 
         """
         self._client = client
-        super(KATCPClientResourceRequest, self).__init__(name, description, is_active)
+        super(KATCPClientResourceRequest, self).__init__(request_description, is_active)
 
     def issue_request(self, *args, **kwargs):
         """Issue the wrapped request to the server.
@@ -887,6 +888,10 @@ class KATCPClientResourceRequest(resource.KATCPRequest):
         instance
 
         """
+        timeout = kwargs.pop('timeout', None)
+        if timeout is None:
+            timeout = self.timeout_hint
+        kwargs['timeout'] = timeout
         return self._client.wrapped_request(self.name, *args, **kwargs)
 
 class GroupRequest(object):
@@ -1010,8 +1015,10 @@ class ClientGroup(object):
     def req(self):
         if self._clients_dirty:
             if any(client.dummy_unknown_requests for client in self.clients):
-                DummyRequest = partial(resource.KATCPDummyRequest,
-                                       'dummy', 'No help for dummies')
+                DummyRequest = partial(
+                    resource.KATCPDummyRequest,
+                    {'name':'dummy', 'description': 'No help for dummies',
+                     'timeout_hint': None})
                 self._req = DefaultAttrDict(DummyRequest)
             else:
                 self._req = AttrDict()

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -551,7 +551,7 @@ class KATCPClientResource(resource.KATCPResource):
         # Otherwise, depend on self._add_sensors() to handle it from the cache when the sensor appears
         raise tornado.gen.Return(sensor_dict)
 
-    def _request_factory(self, name, description):
+    def _request_factory(self, name, description, timeout_hint):
         return KATCPClientResourceRequest(
             name, description, self._inspecting_client, self.is_active)
 

--- a/katcp/server.py
+++ b/katcp/server.py
@@ -1456,6 +1456,8 @@ class DeviceServer(DeviceServerBase):
       * sensor-value
       * watchdog
       * version-list (only standard in KATCP v5 or later)
+      * request-timeout-hint (pre-standard only if protocol flags indicates
+                              timeout hints, supported for KATCP v5.1 or later)
       * sensor-sampling-clear (non-standard)
 
     .. [#restartf1] Restart relies on .set_restart_queue() being used to

--- a/katcp/test/test_inspecting_client.py
+++ b/katcp/test/test_inspecting_client.py
@@ -160,14 +160,6 @@ class TestICAClass(tornado.testing.AsyncTestCase):
 class TestInspectingClientInspect(tornado.testing.AsyncTestCase):
     """Check that inspection populates the request/sensor index correctly"""
 
-    def setUp(self):
-        super(TestInspectingClientInspect, self).setUp()
-        self.server = DeviceTestServer('', 0)
-        start_thread_with_cleanup(self, self.server, start_timeout=1)
-        self.server_with_timeout_hints = DeviceTestServerWithTimeoutHints('', 0)
-        start_thread_with_cleanup(self, self.server_with_timeout_hints,
-                                  start_timeout=1)
-
     def _get_server(self, hints):
         """Return a running test server with or without request timeout hints
 
@@ -201,7 +193,7 @@ class TestInspectingClientInspect(tornado.testing.AsyncTestCase):
         return expected
 
     @tornado.gen.coroutine
-    def _test_inspect_requests_no_timeout_hints(self, timeout_hints):
+    def _test_inspect_requests(self, timeout_hints):
         """Test  index creation
 
         Parameters
@@ -228,11 +220,11 @@ class TestInspectingClientInspect(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_inspect_request_no_timeout_hints(self):
-        yield self._test_inspect_requests_no_timeout_hints(timeout_hints=False)
+        yield self._test_inspect_requests(timeout_hints=False)
 
     @tornado.testing.gen_test
     def test_inspect_request_with_timeout_hints(self):
-        yield self._test_inspect_requests_no_timeout_hints(
+        yield self._test_inspect_requests(
             timeout_hints=True)
 
     # TODO NM 2017-04-12 Tests should be added for sensor index. I just added

--- a/katcp/test/test_inspecting_client.py
+++ b/katcp/test/test_inspecting_client.py
@@ -224,8 +224,7 @@ class TestInspectingClientInspect(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_inspect_request_with_timeout_hints(self):
-        yield self._test_inspect_requests(
-            timeout_hints=True)
+        yield self._test_inspect_requests(timeout_hints=True)
 
     # TODO NM 2017-04-12 Tests should be added for sensor index. I just added
     # the minimum needed to test new functionality for CB-569

--- a/katcp/test/test_inspecting_client.py
+++ b/katcp/test/test_inspecting_client.py
@@ -195,7 +195,8 @@ class TestInspectingClientInspect(tornado.testing.AsyncTestCase):
         hints = getattr(server, 'request_timeout_hints', {})
         expected = {}
         for req, handler in server._request_handlers.items():
-            expected[req] = {'description': handler.__doc__,
+            expected[req] = {'name': req,
+                             'description': handler.__doc__,
                              'timeout_hint': hints.get(req)}
         return expected
 
@@ -434,7 +435,7 @@ class TestInspectingClientAsync(tornado.testing.AsyncTestCase):
             description='An Integer.', name='an.int')
         self.assertIs(req, rf.return_value)
         rf.assert_called_once_with(
-            'watchdog', description=mock.ANY, timeout_hint=None)
+            name='watchdog', description=mock.ANY, timeout_hint=None)
 
 class TestInspectingClientAsyncStateCallback(tornado.testing.AsyncTestCase):
     longMessage = True

--- a/katcp/test/test_resource.py
+++ b/katcp/test/test_resource.py
@@ -112,9 +112,12 @@ class test_KATCPRequest(unittest.TestCase):
         active = False
         is_active = lambda: active
         req_name = 'test-request'
-        req_description = '?test-request description'
-        DUT = ConcreteKATCPRequest(
-            req_name, req_description, is_active=is_active)
+        req_description = {
+            'name': req_name,
+            'description': '?test-request description',
+            'timeout_hint': None}
+
+        DUT = ConcreteKATCPRequest(req_description, is_active=is_active)
         DUT.issue_request = mock.Mock()
 
         req_args = ('arg1', 'arg2')

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -85,11 +85,23 @@ class test_KATCPClientResourceRequest(unittest.TestCase):
         # Check that we are registered to the correct ABC
         self.assertIsInstance(self.DUT, resource.KATCPRequest)
 
-    def test_request(self):
+    def test_request_with_timeout_hint(self):
         reply = self.DUT('parm1', 2)
         self.mock_client.wrapped_request.assert_called_once_with(
             'the-request', 'parm1', 2, timeout=33.34)
         self.assertIs(reply, self.mock_client.wrapped_request.return_value)
+
+    def test_request_no_timeout_hint(self):
+        DUT_no_timeout_hint = resource_client.KATCPClientResourceRequest(
+            {'name': 'the-other-request',
+             'description': 'The other description',
+             'timeout_hint': None},
+            self.mock_client)
+        reply = DUT_no_timeout_hint('aparm', 3)
+        self.mock_client.wrapped_request.assert_called_once_with(
+            'the-other-request', 'aparm', 3, timeout=None)
+        self.assertIs(reply, self.mock_client.wrapped_request.return_value)
+
 
 class test_KATCPClientResource(tornado.testing.AsyncTestCase):
     def test_init(self):


### PR DESCRIPTION
This is an evil idea we hatched at CAM to enable devices to tell clients which requests are likely to be slow. Still experimenting, but if it looks nice we might try and propose it as a KATCP v5.1 protocol feature :)