### PR TITLE
Let ClientGroup wait for a quorum of clients

### DIFF
--- a/katcp/core.py
+++ b/katcp/core.py
@@ -1912,7 +1912,8 @@ def until_some(*args, **kwargs):
     Parameters
     ----------
     done_at_least : None or int
-        Number of futures that need to resolve before this resolves (default all)
+        Number of futures that need to resolve before this resolves or None
+        to wait for all (default None)
     timeout : None or float
         Timeout in seconds, or None for no timeout (the default)
 

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1104,8 +1104,9 @@ class ClientGroup(object):
             The total timeout in seconds (None means wait forever)
         quorum : None or int or float
             The number of clients that are required to satisfy the condition,
-            as either an integer or a float between 0 and 1 indicating a
-            fraction of the total number of clients, rounded up (default all)
+            as either an explicit integer or a float strictly between 0 and 1
+            indicating a fraction of the total number of clients, rounded up.
+            If None, this means that all clients are required (the default).
         max_grace_period : float or None
             After a quorum or initial timeout is reached, wait up to this long
             in an attempt to get the rest of the clients to satisfy condition

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1104,9 +1104,11 @@ class ClientGroup(object):
             The total timeout in seconds (None means wait forever)
         quorum : None or int or float
             The number of clients that are required to satisfy the condition,
-            as either an explicit integer or a float strictly between 0 and 1
-            indicating a fraction of the total number of clients, rounded up.
-            If None, this means that all clients are required (the default).
+            as either an explicit integer or a float between 0 and 1 indicating
+            a fraction of the total number of clients, rounded up. If None,
+            this means that all clients are required (the default). Be warned
+            that a value of 1.0 (float) indicates all clients while a value
+            of 1 (int) indicates a single client...
         max_grace_period : float or None
             After a quorum or initial timeout is reached, wait up to this long
             in an attempt to get the rest of the clients to satisfy condition
@@ -1127,7 +1129,11 @@ class ClientGroup(object):
         """
         if quorum is None:
             quorum = len(self.clients)
-        elif quorum < 1:
+        elif quorum > 1:
+            if not isinstance(quorum, int):
+                raise TypeError('Quorum parameter %r must be an integer '
+                                'if outside range [0, 1]' % (quorum,))
+        elif isinstance(quorum, float):
             quorum = int(math.ceil(quorum * len(self.clients)))
         if timeout and max_grace_period:
             # Avoid having a grace period longer than or equal to timeout

--- a/katcp/test/test_core.py
+++ b/katcp/test/test_core.py
@@ -509,7 +509,7 @@ class TestUntilSome(tornado.testing.AsyncTestCase):
         f1.set_result(24)
         f2.set_result(42)
         results = yield until_some(f1, f2, f3, timeout=0.1)
-        self.assertEqual(results, [(0, 24), (1, 42), (2, 84)],
+        self.assertEqual(sorted(results), [(0, 24), (1, 42), (2, 84)],
                          'Results differ for until_some (3 arg futures)')
 
     @tornado.testing.gen_test

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1095,12 +1095,13 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         DUT = resource_client.KATCPClientResourceContainer(self.default_spec)
         DUT.add_group('test', DUT.children.keys())
         DUT.start()
-        # Setup a new sensor on all clients to wait on
-        wait_sensor = DeviceTestSensor(DeviceTestSensor.INTEGER, 'wait_sensor',
-                                       "An Integer.",
-                                       "count", [-50, 50], timestamp=self.io_loop.time(),
-                                       status=DeviceTestSensor.NOMINAL, value=0)
         for server in self.servers.values():
+            # Setup a new sensor on all clients to wait on
+            wait_sensor = DeviceTestSensor(DeviceTestSensor.INTEGER,
+                                           'wait_sensor', "An Integer.",
+                                           "count", [-50, 50], value=0,
+                                           timestamp=self.io_loop.time(),
+                                           status=DeviceTestSensor.NOMINAL)
             server.add_sensor(wait_sensor)
         yield DUT.until_synced()
         # Ensure strategies are set for wait() to work
@@ -1113,11 +1114,29 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         # Check detailed results per client
         for client in DUT.children.values():
             self.assertTrue(result[client.name])
-        result = yield group.wait('wait_sensor', 1, timeout=0.5)
+        result = yield group.wait('wait_sensor', 1, timeout=0.1)
         self.assertFalse(result)
         for client in DUT.children.values():
             self.assertFalse(result[client.name])
-
+        # Test quorum functionality
+        selected_client = DUT.children.keys()[0]
+        self.servers[selected_client].get_sensor('wait_sensor').set_value(1)
+        result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=1)
+        self.assertTrue(result)
+        result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=0.1)
+        self.assertTrue(result)
+        for client in DUT.children.values():
+            if client.name == selected_client:
+                self.assertTrue(result[client.name])
+            else:
+                self.assertFalse(result[client.name])
+        result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=2)
+        self.assertFalse(result)
+        for client in DUT.children.values():
+            if client.name == selected_client:
+                self.assertTrue(result[client.name])
+            else:
+                self.assertFalse(result[client.name])
 
 
 class test_AttrMappingProxy(unittest.TestCase):

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1111,6 +1111,8 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         # Test the no timeout case too for what it's worth
         result = yield group.wait('wait_sensor', 0, timeout=None)
         self.assertTrue(result)
+        result = yield group.wait('wait_sensor', 0, timeout=None, quorum=1.0)
+        self.assertTrue(result)
         # Check detailed results per client
         for client in DUT.children.values():
             self.assertTrue(result[client.name])
@@ -1119,10 +1121,15 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         for client in DUT.children.values():
             self.assertFalse(result[client.name])
         # Test quorum functionality
+        with self.assertRaises(TypeError):
+            yield group.wait('wait_sensor', 1, timeout=0.1, quorum=1.1)
         selected_client = DUT.children.keys()[0]
         self.servers[selected_client].get_sensor('wait_sensor').set_value(1)
         result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=1)
         self.assertTrue(result)
+        # Be warned that quorum == 1.0 is not the same as quorum == 1 ...
+        result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=1.0)
+        self.assertFalse(result)
         result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=0.1)
         self.assertTrue(result)
         for client in DUT.children.values():


### PR DESCRIPTION
Give ```ClientGroup.wait()``` the ability to wait until a subset of clients (a 'quorum') satisfy a sensor condition. This provides a way to e.g. ignore a broken or stowed receptor while slewing the working receptors onto a target. The wait times out if a quorum could not be achieved in the given timeout period. The desired quorum can be specified as either a number or a fraction of clients.

An additional grace period, which forms part of the overall timeout, allows for some fine-tuning of the behaviour. All remaining clients that have not yet satisfied the condition (the 'stragglers') are given the opportunity to do so within the grace period. This can effectively result in a full quorum by the time the wait resolves, if all clients behave as expected.

The default behaviour is unchanged: the group waits for all clients with a timeout of 5 seconds.

This also introduces the ```until_some``` helper function which returns a future that resolves when *some* of the passed futures resolve, as opposed to *all* (the usual yield on multiple futures) or *any* (the ```until_any``` function).

This addresses JIRA ticket [MKAIV-534](https://skaafrica.atlassian.net/browse/MKAIV-534).