### PR TITLE
User/nmarais/ci 27/initial futurize work for python 2/3 compatibility

### DIFF
--- a/katcp/__init__.py
+++ b/katcp/__init__.py
@@ -4,7 +4,11 @@
 # Copyright 2009 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
 
+
+
 """Root of katcp package."""
+from __future__ import division, print_function, absolute_import
+
 from .core import (Message, KatcpSyntaxError, MessageParser,
                    DeviceMetaclass, FailReply,
                    AsyncReply, KatcpDeviceError, KatcpClientError,

--- a/katcp/client.py
+++ b/katcp/client.py
@@ -5,6 +5,8 @@
 # BSD license - see COPYING for details
 """Clients for the KAT device control language."""
 
+from __future__ import division, print_function, absolute_import
+
 import sys
 import traceback
 import logging

--- a/katcp/core.py
+++ b/katcp/core.py
@@ -6,6 +6,8 @@
 
 """Utilities for dealing with KAT device control language messages."""
 
+from __future__ import division, print_function, absolute_import
+
 import re
 import sys
 import time

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -1,6 +1,7 @@
 # Copyright 2015 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
 
+from __future__ import division, print_function, absolute_import
 
 import tornado.concurrent
 

--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -3,7 +3,8 @@
 # vim:fileencoding=utf8 ai ts=4 sts=4 et sw=4
 # Copyright 2014 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
-from __future__ import print_function
+
+from __future__ import division, print_function, absolute_import
 
 import logging
 import random

--- a/katcp/ioloop_manager.py
+++ b/katcp/ioloop_manager.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, absolute_import
+
 import sys
 import time
 import logging

--- a/katcp/ioloop_manager.py
+++ b/katcp/ioloop_manager.py
@@ -7,13 +7,14 @@ import textwrap
 import tornado.ioloop
 
 from functools import wraps
+from thread import get_ident as get_thread_ident
 
-from peak.util.proxies import ObjectWrapper
 from concurrent.futures import Future, TimeoutError
 from tornado.concurrent import Future as tornado_Future
 from tornado import gen
 
-from thread import get_ident as get_thread_ident
+from katcp.object_proxies import ObjectWrapper
+
 
 log = logging.getLogger(__name__)
 

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -7,6 +7,8 @@
 """Utilities for dealing with KATCP types.
    """
 
+from __future__ import division, print_function, absolute_import
+
 import inspect
 import struct
 import re

--- a/katcp/object_proxies.py
+++ b/katcp/object_proxies.py
@@ -1,0 +1,183 @@
+# Copied from peak.util.proxies https://pypi.python.org/pypi/ProxyTypes/0.9
+# to allow translation to python 2/3 compatible code # According to the pypi
+# index record this code is distributed under PSF (Python Software License) or
+# ZPL (Zope Public License if I' not mistaken). The PSF license is BSD style and
+# allows us to copy, modify and redistribute this code.
+
+class AbstractProxy(object):
+    """Delegates all operations (except ``.__subject__``) to another object"""
+    __slots__ = ()
+
+    def __call__(self,*args,**kw):
+        return self.__subject__(*args,**kw)
+
+    def __getattribute__(self, attr, oga=object.__getattribute__):
+        subject = oga(self,'__subject__')
+        if attr=='__subject__':
+            return subject
+        return getattr(subject,attr)
+
+    def __setattr__(self,attr,val, osa=object.__setattr__):
+        if attr=='__subject__':
+            osa(self,attr,val)
+        else:
+            setattr(self.__subject__,attr,val)
+
+    def __delattr__(self,attr, oda=object.__delattr__):
+        if attr=='__subject__':
+            oda(self,attr)
+        else:
+            delattr(self.__subject__,attr)
+
+    def __nonzero__(self):
+        return bool(self.__subject__)
+
+    def __getitem__(self,arg):
+        return self.__subject__[arg]
+
+    def __setitem__(self,arg,val):
+        self.__subject__[arg] = val
+
+    def __delitem__(self,arg):
+        del self.__subject__[arg]
+
+    def __getslice__(self,i,j):
+        return self.__subject__[i:j]
+
+
+    def __setslice__(self,i,j,val):
+        self.__subject__[i:j] = val
+
+    def __delslice__(self,i,j):
+        del self.__subject__[i:j]
+
+    def __contains__(self,ob):
+        return ob in self.__subject__
+
+    for name in 'repr str hash len abs complex int long float iter oct hex'.split():
+        exec "def __%s__(self): return %s(self.__subject__)" % (name,name)
+
+    for name in 'cmp', 'coerce', 'divmod':
+        exec "def __%s__(self,ob): return %s(self.__subject__,ob)" % (name,name)
+
+    for name,op in [
+        ('lt','<'), ('gt','>'), ('le','<='), ('ge','>='),
+        ('eq','=='), ('ne','!=')
+    ]:
+        exec "def __%s__(self,ob): return self.__subject__ %s ob" % (name,op)
+
+    for name,op in [('neg','-'), ('pos','+'), ('invert','~')]:
+        exec "def __%s__(self): return %s self.__subject__" % (name,op)
+
+    for name, op in [
+        ('or','|'),  ('and','&'), ('xor','^'), ('lshift','<<'), ('rshift','>>'),
+        ('add','+'), ('sub','-'), ('mul','*'), ('div','/'), ('mod','%'),
+        ('truediv','/'), ('floordiv','//')
+    ]:
+        exec (
+            "def __%(name)s__(self,ob):\n"
+            "    return self.__subject__ %(op)s ob\n"
+            "\n"
+            "def __r%(name)s__(self,ob):\n"
+            "    return ob %(op)s self.__subject__\n"
+            "\n"
+            "def __i%(name)s__(self,ob):\n"
+            "    self.__subject__ %(op)s=ob\n"
+            "    return self\n"
+        )  % locals()
+
+    del name, op
+
+    # Oddball signatures
+
+    def __rdivmod__(self,ob):
+        return divmod(ob, self.__subject__)
+
+    def __pow__(self,*args):
+        return pow(self.__subject__,*args)
+
+    def __ipow__(self,ob):
+        self.__subject__ **= ob
+        return self
+
+    def __rpow__(self,ob):
+        return pow(ob, self.__subject__)
+
+
+class ObjectProxy(AbstractProxy):
+    """Proxy for a specific object"""
+
+    __slots__ = "__subject__"
+
+    def __init__(self,subject):
+        self.__subject__ = subject
+
+
+class CallbackProxy(AbstractProxy):
+    """Proxy for a dynamically-chosen object"""
+
+    __slots__ = '__callback__'
+
+    def __init__(self, func):
+        set_callback(self,func)
+
+set_callback = CallbackProxy.__callback__.__set__
+get_callback = CallbackProxy.__callback__.__get__
+CallbackProxy.__subject__ = property(lambda self, gc=get_callback: gc(self)())
+
+
+
+class LazyProxy(CallbackProxy):
+    """Proxy for a lazily-obtained object, that is cached on first use"""
+    __slots__ = "__cache__"
+
+get_cache = LazyProxy.__cache__.__get__
+set_cache = LazyProxy.__cache__.__set__
+
+def __subject__(self, get_cache=get_cache, set_cache=set_cache):
+    try:
+        return get_cache(self)
+    except AttributeError:
+        set_cache(self, get_callback(self)())
+        return get_cache(self)
+
+LazyProxy.__subject__ = property(__subject__, set_cache)
+del __subject__
+
+
+class AbstractWrapper(AbstractProxy):
+    """Mixin to allow extra behaviors and attributes on proxy instance"""
+    __slots__ = ()
+
+    def __getattribute__(self, attr, oga=object.__getattribute__):
+        if attr.startswith('__'):
+            subject = oga(self,'__subject__')
+            if attr=='__subject__':
+                return subject
+            return getattr(subject,attr)
+        return oga(self,attr)
+
+    def __getattr__(self,attr, oga=object.__getattribute__):
+        return getattr(oga(self,'__subject__'), attr)
+
+    def __setattr__(self,attr,val, osa=object.__setattr__):
+        if (
+            attr=='__subject__'
+            or hasattr(type(self),attr) and not attr.startswith('__')
+        ):
+            osa(self,attr,val)
+        else:
+            setattr(self.__subject__,attr,val)
+
+    def __delattr__(self,attr, oda=object.__delattr__):
+        if (
+            attr=='__subject__'
+            or hasattr(type(self),attr) and not attr.startswith('__')
+        ):
+            oda(self,attr)
+        else:
+            delattr(self.__subject__,attr)
+
+class ObjectWrapper(ObjectProxy, AbstractWrapper):      __slots__ = ()
+class CallbackWrapper(CallbackProxy, AbstractWrapper):  __slots__ = ()
+class LazyWrapper(LazyProxy, AbstractWrapper):          __slots__ = ()

--- a/katcp/object_proxies.py
+++ b/katcp/object_proxies.py
@@ -4,6 +4,8 @@
 # ZPL (Zope Public License if I' not mistaken). The PSF license is BSD style and
 # allows us to copy, modify and redistribute this code.
 
+from __future__ import division, print_function, absolute_import
+
 # Python 2/3 compatibility stuff
 from builtins import object
 #

--- a/katcp/object_proxies.py
+++ b/katcp/object_proxies.py
@@ -4,6 +4,10 @@
 # ZPL (Zope Public License if I' not mistaken). The PSF license is BSD style and
 # allows us to copy, modify and redistribute this code.
 
+# Python 2/3 compatibility stuff
+from builtins import object
+#
+
 class AbstractProxy(object):
     """Delegates all operations (except ``.__subject__``) to another object"""
     __slots__ = ()
@@ -29,7 +33,7 @@ class AbstractProxy(object):
         else:
             delattr(self.__subject__,attr)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.__subject__)
 
     def __getitem__(self,arg):
@@ -55,26 +59,26 @@ class AbstractProxy(object):
         return ob in self.__subject__
 
     for name in 'repr str hash len abs complex int long float iter oct hex'.split():
-        exec "def __%s__(self): return %s(self.__subject__)" % (name,name)
+        exec("def __%s__(self): return %s(self.__subject__)" % (name,name))
 
     for name in 'cmp', 'coerce', 'divmod':
-        exec "def __%s__(self,ob): return %s(self.__subject__,ob)" % (name,name)
+        exec("def __%s__(self,ob): return %s(self.__subject__,ob)" % (name,name))
 
     for name,op in [
         ('lt','<'), ('gt','>'), ('le','<='), ('ge','>='),
         ('eq','=='), ('ne','!=')
     ]:
-        exec "def __%s__(self,ob): return self.__subject__ %s ob" % (name,op)
+        exec("def __%s__(self,ob): return self.__subject__ %s ob" % (name,op))
 
     for name,op in [('neg','-'), ('pos','+'), ('invert','~')]:
-        exec "def __%s__(self): return %s self.__subject__" % (name,op)
+        exec("def __%s__(self): return %s self.__subject__" % (name,op))
 
     for name, op in [
         ('or','|'),  ('and','&'), ('xor','^'), ('lshift','<<'), ('rshift','>>'),
         ('add','+'), ('sub','-'), ('mul','*'), ('div','/'), ('mod','%'),
         ('truediv','/'), ('floordiv','//')
     ]:
-        exec (
+        exec((
             "def __%(name)s__(self,ob):\n"
             "    return self.__subject__ %(op)s ob\n"
             "\n"
@@ -84,7 +88,7 @@ class AbstractProxy(object):
             "def __i%(name)s__(self,ob):\n"
             "    self.__subject__ %(op)s=ob\n"
             "    return self\n"
-        )  % locals()
+        )  % locals())
 
     del name, op
 

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -1,5 +1,7 @@
 """A high-level abstract interface to KATCP clients, sensors and requests."""
 
+from __future__ import division, print_function, absolute_import
+
 import abc
 import sys
 import collections

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1,5 +1,12 @@
 # Copyright 2014 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
+from __future__ import division
+
+# Python 2/3 compatibility stuff
+from builtins import str
+from past.utils import old_div
+from builtins import object
+#
 
 import logging
 import sys
@@ -669,7 +676,7 @@ class KATCPClientResource(resource.KATCPResource):
         sensor_instances = yield sensor_instance_fut
         # Store KATCPSensor instances in self.sensor
         added_names = []
-        for s_name, s_obj in sensor_instances.items():
+        for s_name, s_obj in list(sensor_instances.items()):
             s_name_escaped = resource.escape_name(s_name)
             self._sensor[s_name_escaped] = s_obj
             preset_strategy = self._sensor_strategy_cache.get(s_name_escaped)
@@ -814,7 +821,7 @@ class KATCPClientResourceSensorsManager(object):
     def reapply_sampling_strategies(self):
         """Reapply all sensor strategies using cached values"""
         check_sensor = self._inspecting_client.future_check_sensor
-        for sensor_name, strategy in self._strategy_cache.items():
+        for sensor_name, strategy in list(self._strategy_cache.items()):
             try:
                 sensor_exists = yield check_sensor(sensor_name)
                 if not sensor_exists:
@@ -823,7 +830,7 @@ class KATCPClientResourceSensorsManager(object):
                     continue
 
                 result = yield self.set_sampling_strategy(sensor_name, strategy)
-            except KATCPSensorError, e:
+            except KATCPSensorError as e:
                 self._logger.error('Error reapplying strategy for sensor {0}: {1!s}'
                                    .format(sensor_name, e))
             except Exception:
@@ -975,9 +982,14 @@ class GroupResults(dict):
     should work as expected.
 
     """
-    def __nonzero__(self):
+    def __bool__(self):
         """True if katcp request succeeded on all clients."""
-        return all(self.itervalues())
+        return all(self.values())
+
+    # Was not handled automatrically by futurize, see
+    # https://github.com/PythonCharmers/python-future/issues/282
+    if sys.version_info[0] == 2:
+        __nonzero__ = __bool__
 
     @property
     def succeeded(self):
@@ -1162,8 +1174,10 @@ class ClientGroup(object):
             """Dictionary of results that can be tested for overall success."""
             def __bool__(self):
                 return sum(self.values()) >= quorum
-            def __nonzero__(self):
-                return self.__bool__()
+            # Was not handled automatrically by futurize, see
+            # https://github.com/PythonCharmers/python-future/issues/282
+            if sys.version_info[0] == 2:
+                __nonzero__ = __bool__
         raise tornado.gen.Return(TestableDict(results))
 
 
@@ -1276,7 +1290,7 @@ class KATCPClientResourceContainer(resource.KATCPResource):
     def _init_groups(self):
         group_configs = self._resources_spec.get('groups', {})
         groups = AttrDict()
-        for group_name, group_client_names in group_configs.items():
+        for group_name, group_client_names in list(group_configs.items()):
             group_clients = tuple(self.children[resource.escape_name(cn)]
                                   for cn in group_client_names)
             group = ClientGroup(group_name, group_clients)
@@ -1540,7 +1554,7 @@ class AttrMappingProxy(MappingProxy):
         return self._wrapper(getattr(self._mapping, attr))
 
     def __dir__(self):
-        return self.keys()
+        return list(self.keys())
 
 
 class ThreadSafeKATCPClientGroupWrapper(ThreadSafeMethodAttrWrapper):

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -1,6 +1,6 @@
 # Copyright 2014 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 
 # Python 2/3 compatibility stuff
 from builtins import str

--- a/katcp/sampling.py
+++ b/katcp/sampling.py
@@ -6,6 +6,8 @@
 
 """Strategies for sampling sensor values."""
 
+from __future__ import division, print_function, absolute_import
+
 import logging
 import os
 

--- a/katcp/sensortree.py
+++ b/katcp/sensortree.py
@@ -23,6 +23,7 @@ that the update chain eventually terminates. It is not enforced.
 
 """
 
+from __future__ import division, print_function, absolute_import
 
 class GenericSensorTree(object):
     """A tree of generic sensors."""

--- a/katcp/server.py
+++ b/katcp/server.py
@@ -6,6 +6,8 @@
 
 """Servers for the KAT device control language."""
 
+from __future__ import division, print_function, absolute_import
+
 import socket
 import threading
 import traceback

--- a/katcp/test/test_client.py
+++ b/katcp/test/test_client.py
@@ -6,6 +6,8 @@
 
 """Tests for client module."""
 
+from __future__ import division, print_function, absolute_import
+
 import unittest2 as unittest
 import socket
 import mock
@@ -734,8 +736,8 @@ class TestCallbackClient(unittest.TestCase, TestUtilMixin):
             self.assertEqual(replies[0].arguments[0], "ok")
             informs = remove_version_connect(informs)
             if len(informs) != NO_HELP_MESSAGES:
-                print thread_id, len(informs)
-                print [x.arguments[0] for x in informs]
+                print(thread_id, len(informs))
+                print([x.arguments[0] for x in informs])
             self.assertEqual(len(informs), NO_HELP_MESSAGES)
 
     def test_blocking_request(self):

--- a/katcp/test/test_core.py
+++ b/katcp/test/test_core.py
@@ -6,6 +6,7 @@
 
 """Tests for the katcp utilities module.
    """
+from __future__ import division, print_function, absolute_import
 
 # Python 2/3 compatibility stuff
 from builtins import str

--- a/katcp/test/test_core.py
+++ b/katcp/test/test_core.py
@@ -7,8 +7,10 @@
 """Tests for the katcp utilities module.
    """
 
+from builtins import str
+from builtins import object
 import logging
-import unittest2 as unittest
+import unittest
 
 import tornado
 

--- a/katcp/test/test_core.py
+++ b/katcp/test/test_core.py
@@ -7,10 +7,12 @@
 """Tests for the katcp utilities module.
    """
 
+# Python 2/3 compatibility stuff
 from builtins import str
 from builtins import object
 import logging
 import unittest
+#
 
 import tornado
 

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -1,6 +1,7 @@
 # Copyright 2015 SKA South Africa (http://ska.ac.za/)
 # BSD license - see COPYING for details
-from __future__ import division
+
+from __future__ import division, print_function, absolute_import
 
 import unittest2 as unittest
 import logging

--- a/katcp/test/test_inspecting_client.py
+++ b/katcp/test/test_inspecting_client.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import logging
 import time
 import collections

--- a/katcp/test/test_ioloop_manager.py
+++ b/katcp/test/test_ioloop_manager.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, absolute_import
+
 import unittest
 
 from thread import get_ident as get_thread_ident

--- a/katcp/test/test_katcp_bnf.py
+++ b/katcp/test/test_katcp_bnf.py
@@ -35,6 +35,8 @@
     Uses the ply library from http://www.dabeaz.com/ply/.
     """
 
+from __future__ import division, print_function, absolute_import
+
 import ply.lex as lex
 import ply.yacc as yacc
 import katcp

--- a/katcp/test/test_kattypes.py
+++ b/katcp/test/test_kattypes.py
@@ -7,6 +7,8 @@
 """Tests for the kattypes module.
    """
 
+from __future__ import division, print_function, absolute_import
+
 import unittest2 as unittest
 import mock
 from katcp import Message, FailReply, AsyncReply

--- a/katcp/test/test_resource.py
+++ b/katcp/test/test_resource.py
@@ -6,6 +6,7 @@
 # THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
 # WRITTEN PERMISSION OF SKA SA.                                               #
 ###############################################################################
+from __future__ import division, print_function, absolute_import
 
 import unittest
 import logging

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ###############################################################################
 # SKA South Africa (http://ska.ac.za/)                                        #
 # Author: cam@ska.ac.za                                                       #
@@ -7,7 +8,14 @@
 # WRITTEN PERMISSION OF SKA SA.                                               #
 ###############################################################################
 
-import unittest2 as unittest
+# Python 2/3 compatibility stuff
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
+#
+
+import unittest
 import logging
 import copy
 import time
@@ -16,7 +24,7 @@ import threading
 import tornado
 import mock
 
-from thread import get_ident as get_thread_ident
+from _thread import get_ident as get_thread_ident
 from functools import partial
 
 from concurrent.futures import TimeoutError
@@ -265,7 +273,8 @@ class test_KATCPClientResource(tornado.testing.AsyncTestCase):
 
         def make_test_sensors(sensors_info):
             test_sensors = AttrDict()
-            for sens_pyname, info in sensors_info.items():
+            # TODO PY3 check if we can get rid of the list() call
+            for sens_pyname, info in list(sensors_info.items()):
                 info = dict(info)
                 info['sensor_type'] = Sensor.INTEGER
                 val = info.pop('value')
@@ -628,7 +637,8 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         self.assertEqual(sorted(DUT.groups), ['group1', 'group2', 'group3', 'group4'])
         spec['groups']['group4'] = ('client-2', 'another-client')
 
-        for group_name, group in DUT.groups.items():
+        # TODO PY3 check if we can get rid of the list() call
+        for group_name, group in list(DUT.groups.items()):
             # Smoke test that no errors are raised
             group.req
             # Check that the correct clients are in each group
@@ -674,8 +684,9 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         m_i_c_2 = mock_inspecting_client(DUT.children.client_2)
         m_i_c_a = mock_inspecting_client(DUT.children.another_client)
 
+        # TODO PY3 check if we can get rid of the list() call
         normalize_reply = lambda reply: {c:r if r is None else str(r.reply)
-                                          for c, r in reply.items()}
+                                          for c, r in list(reply.items())}
 
         yield DUT.children.client1._add_requests(['req-1'])
         g1_reply = yield DUT.groups.group1.req.req_1()
@@ -707,7 +718,8 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         child_specs = self.default_spec_orig['clients']
         self.assertEqual(sorted(DUT.children),
                          sorted(resource.escape_name(n) for n in child_specs))
-        for child_name, child_spec in child_specs.items():
+        # TODO PY3 check if we can get rid of the list() call
+        for child_name, child_spec in list(child_specs.items()):
             child = DUT.children[resource.escape_name(child_name)]
             self.assertEqual(child.name, child_name)
             self.assertEqual(child.parent, DUT)
@@ -721,7 +733,8 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         dict.update(DUT.children, mock_children)
 
         self.assertTrue(DUT.is_active(), "'active' should be True initially")
-        for child_name, child in DUT.children.items():
+        # TODO PY3 check if we can get rid of the list() call
+        for child_name, child in list(DUT.children.items()):
             self.assertTrue(child.is_active(),
                             "Child {} should be active".format(child_name))
 
@@ -730,7 +743,8 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         self.assertFalse(DUT.is_active(),
                          "'active' should be False after set_active(False)")
 
-        for child_name, child in DUT.children.items():
+        # TODO PY3 check if we can get rid of the list() call
+        for child_name, child in list(DUT.children.items()):
             self.assertFalse(child.is_active(),
                             "Child {} should not be active".format(child_name))
 
@@ -738,7 +752,8 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         DUT.set_active(True)
         self.assertTrue(DUT.is_active(),
                         "'active' should be True after set_active(True)")
-        for child_name, child in DUT.children.items():
+        # TODO PY3 check if we can get rid of the list() call
+        for child_name, child in list(DUT.children.items()):
             self.assertTrue(child.is_active(),
                             "Child {} should be active".format(child_name))
 
@@ -750,7 +765,8 @@ class test_KATCPClientResourceContainer(tornado.testing.AsyncTestCase):
         self.assertTrue(DUT.until_not_synced().done())
 
         # Set all child states sync functions to resolved and not_synced to unresolved
-        for child in DUT.children.values():
+        # TODO PY3 check if we can get rid of the list() call
+        for child in list(DUT.children.values()):
             f = tornado.concurrent.Future()
             f.set_result(None)
             child.until_synced = mock.create_autospec(
@@ -806,7 +822,7 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
             'resource2' : dict(controlled=True),
             'resource3' : dict(controlled=True)},
                                  name='intgtest')
-        self.resource_names = self.default_spec['clients'].keys()
+        self.resource_names = list(self.default_spec['clients'].keys())
         self.servers = {rn: DeviceTestServer('', 0) for rn in self.resource_names}
         for i, (s_name, s) in enumerate(sorted(self.servers.items())):
             start_thread_with_cleanup(self, s)
@@ -1031,7 +1047,7 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         katcp_sensor.set(t, status, value)
         t, status, value = (t0+2.5, Sensor.NOMINAL, 3)
         katcp_sensor.set(t, status, value)
-        print "listener.mock_calls", listener.mock_calls
+        print("listener.mock_calls", listener.mock_calls)
         self.assertEquals(len(listener.mock_calls), 6)
         return
 
@@ -1093,9 +1109,10 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         # Start new container
         self.default_spec_orig = copy.deepcopy(self.default_spec)
         DUT = resource_client.KATCPClientResourceContainer(self.default_spec)
-        DUT.add_group('test', DUT.children.keys())
+        DUT.add_group('test', list(DUT.children.keys()))
         DUT.start()
-        for server in self.servers.values():
+        # TODO PY3 check if we can get rid of the list() call
+        for server in list(self.servers.values()):
             # Setup a new sensor on all clients to wait on
             wait_sensor = DeviceTestSensor(DeviceTestSensor.INTEGER,
                                            'wait_sensor', "An Integer.",
@@ -1105,7 +1122,8 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
             server.add_sensor(wait_sensor)
         yield DUT.until_synced()
         # Ensure strategies are set for wait() to work
-        for client in DUT.children.values():
+        # TODO PY3 check if we can get rid of the list() call
+        for client in list(DUT.children.values()):
             client.set_sampling_strategy('wait_sensor', 'event')
         group = DUT.groups['test']
         # Test the no timeout case too for what it's worth
@@ -1114,16 +1132,19 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         result = yield group.wait('wait_sensor', 0, timeout=None, quorum=1.0)
         self.assertTrue(result)
         # Check detailed results per client
-        for client in DUT.children.values():
+        # TODO PY3 check if we can get rid of the list() call
+        for client in list(DUT.children.values()):
             self.assertTrue(result[client.name])
         result = yield group.wait('wait_sensor', 1, timeout=0.1)
         self.assertFalse(result)
-        for client in DUT.children.values():
+        # TODO PY3 check if we can get rid of the list() call
+        for client in list(DUT.children.values()):
             self.assertFalse(result[client.name])
         # Test quorum functionality
         with self.assertRaises(TypeError):
             yield group.wait('wait_sensor', 1, timeout=0.1, quorum=1.1)
-        selected_client = DUT.children.keys()[0]
+        # TODO PY3 check if we can get rid of the list() call
+        selected_client = list(DUT.children.keys())[0]
         self.servers[selected_client].get_sensor('wait_sensor').set_value(1)
         result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=1)
         self.assertTrue(result)
@@ -1132,14 +1153,16 @@ class test_KATCPClientResourceContainerIntegrated(tornado.testing.AsyncTestCase)
         self.assertFalse(result)
         result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=0.1)
         self.assertTrue(result)
-        for client in DUT.children.values():
+        # TODO PY3 check if we can get rid of the list() call
+        for client in list(DUT.children.values()):
             if client.name == selected_client:
                 self.assertTrue(result[client.name])
             else:
                 self.assertFalse(result[client.name])
         result = yield group.wait('wait_sensor', 1, timeout=0.1, quorum=2)
         self.assertFalse(result)
-        for client in DUT.children.values():
+        # TODO PY3 check if we can get rid of the list() call
+        for client in list(DUT.children.values()):
             if client.name == selected_client:
                 self.assertTrue(result[client.name])
             else:
@@ -1158,7 +1181,8 @@ class test_AttrMappingProxy(unittest.TestCase):
 
         wrapped_dict = resource_client.AttrMappingProxy(test_dict, TestWrapper)
         # Test keys
-        self.assertEqual(wrapped_dict.keys(), test_dict.keys())
+        # TODO PY3 check if we can get rid of the list() call
+        self.assertEqual(list(wrapped_dict.keys()), list(test_dict.keys()))
         # Test key access:
         for key in test_dict:
             self.assertEqual(wrapped_dict[key].wrappee, test_dict[key])
@@ -1167,8 +1191,10 @@ class test_AttrMappingProxy(unittest.TestCase):
             self.assertEqual(getattr(wrapped_dict, key).wrappee,
                              getattr(test_dict, key))
         # Test whole dict comparison
-        self.assertEqual(wrapped_dict,
-                         {k : TestWrapper(v) for k, v in test_dict.items()})
+        # TODO PY3 check if we can get rid of the list() call
+        self.assertEqual(
+            wrapped_dict,
+            {k : TestWrapper(v) for k, v in list(test_dict.items())})
 
 
 class test_ThreadSafeKATCPClientResourceWrapper(unittest.TestCase):
@@ -1245,7 +1271,8 @@ class test_ThreadSafeKATCPClientResourceWrapper_container(unittest.TestCase):
             'resource1' : dict(controlled=True),
             'resource2' : dict(controlled=True)},
                                  name='wraptest')
-        self.resource_names = self.default_spec['clients'].keys()
+        # TODO PY3 check if we can get rid of the list() call
+        self.resource_names = list(self.default_spec['clients'].keys())
         self.servers = {rn: DeviceTestServer('', 0) for rn in self.resource_names}
         for i, (s_name, s) in enumerate(sorted(self.servers.items())):
             start_thread_with_cleanup(self, s)

--- a/katcp/test/test_resource_client.py
+++ b/katcp/test/test_resource_client.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, division, absolute_import
 ###############################################################################
 # SKA South Africa (http://ska.ac.za/)                                        #
 # Author: cam@ska.ac.za                                                       #
@@ -7,6 +7,7 @@ from __future__ import print_function
 # THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
 # WRITTEN PERMISSION OF SKA SA.                                               #
 ###############################################################################
+from __future__ import division, print_function, absolute_import
 
 # Python 2/3 compatibility stuff
 from future import standard_library

--- a/katcp/test/test_sampling.py
+++ b/katcp/test/test_sampling.py
@@ -7,6 +7,8 @@
 """Tests for the katcp.sampling module.
    """
 
+from __future__ import division, print_function, absolute_import
+
 import unittest2 as unittest
 import threading
 import time

--- a/katcp/test/test_sensortree.py
+++ b/katcp/test/test_sensortree.py
@@ -1,5 +1,7 @@
 """Tests for the nodeman module."""
 
+from __future__ import division, print_function, absolute_import
+
 import unittest
 import katcp
 

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -6,6 +6,7 @@
 
 """Tests for the server module.
    """
+from __future__ import division, print_function, absolute_import
 
 import unittest2 as unittest
 import sys

--- a/katcp/test/test_testutils.py
+++ b/katcp/test/test_testutils.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 
 import unittest2 as unittest
 import threading

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -23,7 +23,6 @@ from thread import get_ident
 from tornado import gen
 from tornado.concurrent import Future as tornado_Future
 from concurrent.futures import Future, TimeoutError
-from peak.util.proxies import ObjectWrapper
 
 from .core import (Sensor,
                    Message,
@@ -38,6 +37,7 @@ from .kattypes import (request,
                        Float, Str, Int,
                        concurrent_reply,
                        request_timeout_hint)
+from .object_proxies import ObjectWrapper
 
 logger = logging.getLogger(__name__)
 

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -6,7 +6,8 @@
 
 """Test utils for katcp package tests."""
 
-import client
+from __future__ import division, print_function, absolute_import
+
 import logging
 import re
 import time
@@ -23,6 +24,9 @@ from thread import get_ident
 from tornado import gen
 from tornado.concurrent import Future as tornado_Future
 from concurrent.futures import Future, TimeoutError
+
+from katcp import client
+
 
 from .core import (Sensor,
                    Message,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         "ply",
         "tornado>=4.0",
         "futures",
-        "ProxyTypes"
+        "ProxyTypes",
+        "future"
     ],
     # run tests and install these requirements with python setup.py nosetests
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "ply",
         "tornado>=4.0",
         "futures",
-        "ProxyTypes",
         "future"
     ],
     # run tests and install these requirements with python setup.py nosetests


### PR DESCRIPTION
Futurize a small part of KATCP lib as a proof of concept. Also got rid of the python 2 ProxyTypes dependency by moving it into our codebase (only about 200 lines) and also making it python 2/3 compatible.

Going forward, files that have been marked with `# Python 2/3 compatibility stuff` comment near the top should use python 2/3 compatible idioms: http://python-future.org/compatible_idioms.html