### PR TITLE
Bumped tornado dependency to 4.3 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     use_katversion=True,
     install_requires=[
         "ply",
-        "tornado>=4.0",
+        "tornado>=4.3",
         "futures",
         "future"
     ],


### PR DESCRIPTION
This is necessary because the `tornado.gen.Multi` class and the function
`multi_future` was replaced with a unified function `multi` in 4.3. We
use `multi` since df82a33252a1d6196646b4a267cbf9583301f919 (didn't check
earlier commits)