### PR TITLE
Increase container sync time as the 8s timeout with 1s kickoff 

### DIFF
--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -195,8 +195,8 @@ class InspectingClientAsync(object):
     # TODO (NM 2016-10-21) sync_timeout should be 5 seconds, but until we deal
     # with the thundering herd at startup when connecting to a large number of
     # clients concurrently in a single process, see Jira CB-1609
-    sync_timeout = 8
-    initial_resync_timeout = 1
+    sync_timeout = 20
+    initial_resync_timeout = 5
     max_resync_timeout = 90
 
     def __init__(self, host, port, ioloop=None, initial_inspection=None,


### PR DESCRIPTION
just aggrevated the situation of multiple clients connecting at the same time.

Tested on dev64 and cam.status() for the full 64-dish container settles nicely within ~5s after configure_cam() without a myriad of error messages.