### PR TITLE
A descriptive error message for the DeviceMetaClass assert statements

### DIFF
--- a/katcp/core.py
+++ b/katcp/core.py
@@ -717,19 +717,22 @@ class DeviceMetaclass(type):
                 request_name = convert_method_name("request_", name)
                 if mcs.check_protocol(handler):
                     mcs._request_handlers[request_name] = handler
-                    assert(handler.__doc__ is not None)
+                    error_msg = "Request '{}' has no docstring.".format(request_name)
+                    assert(handler.__doc__ is not None), error_msg
             elif name.startswith("inform_"):
                 inform_name = convert_method_name("inform_", name)
                 if mcs.check_protocol(handler):
                     mcs._inform_handlers[inform_name] = handler
-                    assert(handler.__doc__ is not None)
+                    error_msg = "Inform '{}' has no doctring.".format(inform_name)
+                    assert(handler.__doc__ is not None), error_msg
                 # There is a bit of a name colission between the reply_*
                 # convention and the server reply_inform() method
             elif name.startswith("reply_") and name != 'reply_inform':
                 reply_name = convert_method_name("reply_", name)
                 if mcs.check_protocol(handler):
                     mcs._reply_handlers[reply_name] = handler
-                    assert(handler.__doc__ is not None)
+                    error_msg = "Reply '{}' has no doctring.".format(reply_name)
+                    assert(handler.__doc__ is not None), error_msg
 
     def check_protocol(mcs, handler):
         """Return False if `handler` should be filtered"""

--- a/katcp/core.py
+++ b/katcp/core.py
@@ -723,15 +723,15 @@ class DeviceMetaclass(type):
                 inform_name = convert_method_name("inform_", name)
                 if mcs.check_protocol(handler):
                     mcs._inform_handlers[inform_name] = handler
-                    error_msg = "Inform '{}' has no doctring.".format(inform_name)
+                    error_msg = "Inform '{}' has no docstring.".format(inform_name)
                     assert(handler.__doc__ is not None), error_msg
-                # There is a bit of a name colission between the reply_*
+                # There is a bit of a name collision between the reply_*
                 # convention and the server reply_inform() method
             elif name.startswith("reply_") and name != 'reply_inform':
                 reply_name = convert_method_name("reply_", name)
                 if mcs.check_protocol(handler):
                     mcs._reply_handlers[reply_name] = handler
-                    error_msg = "Reply '{}' has no doctring.".format(reply_name)
+                    error_msg = "Reply '{}' has no docstring.".format(reply_name)
                     assert(handler.__doc__ is not None), error_msg
 
     def check_protocol(mcs, handler):


### PR DESCRIPTION
Providing meaningful error messages for when the asserts fail.