### PR TITLE
Increase MAX_QUEUE_SIZE to handle more clients

### DIFF
--- a/katcp/server.py
+++ b/katcp/server.py
@@ -820,7 +820,7 @@ class MessageHandlerThread(object):
         *on_message* should not be called again until *ready* has resolved.
 
         """
-        MAX_QUEUE_SIZE = 30
+        MAX_QUEUE_SIZE = 300
         if len(self._msg_queue) >= MAX_QUEUE_SIZE:
             # This should never happen if callers to handle_message wait
             # for its futures to resolve before sending another message.


### PR DESCRIPTION
Increase in queue size to cater for more concurrent client connections.  One of our processes has around 90 clients.

This was hotfixed in a release branch, PR #199, about a year ago.  Forgot to add to to master.

Ideally the limit should be a function of the number of connected clients, but that is more effort to implement.  Note that the limit used to be just 3, assuming a single client - this was changed in 6aabfb8bd1e to allow for "multiple" clients.

JIRA: [MT-92](https://skaafrica.atlassian.net/browse/MT-92)