### PR TITLE
Updated license header on files.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,9 +11,8 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
-
-    * Neither the name of the National Research Foundation
-      (South African Radio Astronomy Observatory) project nor the names of its
+    * Neither the name of the National Research Foundation or
+      South African Radio Astronomy Observatory nor the names of its
       contributors may be used to endorse or promote products derived from this
       software without specific prior written permission.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2009, 2010 National Research Foundation (South African Radio Astronomy Observatory)
+Copyright (c) 2009, 2010 National Research Foundation
+(South African Radio Astronomy Observatory)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +12,8 @@ modification, are permitted provided that the following conditions are met:
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
 
-    * Neither the name of the National Research Foundation (South African Radio Astronomy Observatory) project nor the names of its
+    * Neither the name of the National Research Foundation
+      (South African Radio Astronomy Observatory) project nor the names of its
       contributors may be used to endorse or promote products derived from this
       software without specific prior written permission.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009, 2010 SKA South Africa
+Copyright (c) 2009, 2010 National Research Foundation (South African Radio Astronomy Observatory)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
 
-    * Neither the name of the SKA South Africa project nor the names of its
+    * Neither the name of the National Research Foundation (South African Radio Astronomy Observatory) project nor the names of its
       contributors may be used to endorse or promote products derived from this
       software without specific prior written permission.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'KATCP'
-copyright = u'2009-2012, SKA South Africa'
+copyright = u'2009-2012, National Research Foundation (South African Radio Astronomy Observatory)'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,13 @@ from katcp import __version__  # noqa: E402
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.autosummary', 'numpydoc']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.todo',
+    'sphinx.ext.imgmath',
+    'sphinx.ext.autosummary',
+    'numpydoc'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -47,7 +53,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'KATCP'
-copyright = u'2009-2012, National Research Foundation (South African Radio Astronomy Observatory)'
+copyright = (
+    u'2009, National Research Foundation '
+    '(South African Radio Astronomy Observatory)')
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -1,5 +1,5 @@
-# Copyright 2015 SKA South Africa (http://ska.ac.za/)
-# BSD license - see COPYING for details
+# Copyright 2015 National Research Foundation (South African Radio Astronomy Observatory)
+# BSD license - see LICENSE for details
 
 from __future__ import absolute_import, division, print_function
 from future import standard_library


### PR DESCRIPTION
Renamed license header from *SKA South Africa* to *National Research Foundation (South African Radio Astronomy Observatory)*, which is consistent across most of the files.