### PR TITLE
Removed pip's index and trusted hosts

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,6 @@ envlist = py{27, 36},docs
 
 [testenv]
 passenv = test_flags
-install_command = pip install \
-                        --index-url=http://pypi.camlab.kat.ac.za/pypi/trusty \
-                        --trusted-host=pypi.camlab.kat.ac.za {opts} {packages}
 commands =
     coverage run --source={env:test_flags} -m nose --xunit-file=nosetests_{envname}.xml
     coverage xml -o coverage_{envname}.xml


### PR DESCRIPTION
This PR does the following:

- Removes pip index and trusted hosts related information from `tox.ini` file.