### PR TITLE
Improve Sensor, Message and Server class docstrings 

### DIFF
--- a/katcp/core.py
+++ b/katcp/core.py
@@ -900,24 +900,31 @@ class Sensor(object):
         The type of sensor.
     name : str
         The name of the sensor.
-    description : str
+    description : str, optional
         A short description of the sensor.
-    units : str
+    units : str, optional
         The units of the sensor value. May be the empty string
         if there are no applicable units.
-    params : list
+    params : list, optional
         Additional parameters, dependent on the type of sensor:
 
-          * For :const:`INTEGER` and :const:`FLOAT` the list should
-            give the minimum and maximum that define the range
-            of the sensor value.
-          * For :const:`DISCRETE` the list should contain all
-            possible values the sensor may take.
+          * For :const:`INTEGER` and :const:`FLOAT` the list is optional.
+            If provided, it should have two items, providing the minimum
+            and maximum that define the range of the sensor value,
+            respectively. The type of each item must be int, or float.
+          * For :const:`DISCRETE` the list is required, and must
+            contain all possible values the sensor may take. There
+            must be at least one item.  The type of each item must be
+            str or bytes.
           * For all other types, params should be omitted.
-    default : object
+    default : object, optional
         An initial value for the sensor. By default this is
         determined by the sensor type.
-    initial_status : int enum or None
+        For :const:`INTEGER` and :const:`FLOAT` sensors,
+        if no default is provided, but valid minimum and
+        maximum parameters are, the default will be set to
+        the minimum.
+    initial_status : int enum or None, optional
         An initial status for the sensor. If None, defaults to
         Sensor.UNKNOWN. `initial_status` must be one of the keys in
         Sensor.STATUSES

--- a/katcp/core.py
+++ b/katcp/core.py
@@ -254,15 +254,6 @@ class Message(object):
     ## @brief Regular expression matching all unescaped character.
     ESCAPE_RE = re.compile(br"[\\ \0\n\r\x1b\t]")
 
-    ## @var mtype
-    # @brief Message type.
-
-    ## @var name
-    # @brief Message name.
-
-    ## @var arguments
-    # @brief List of string message arguments.
-
     ## @brief Attempt to optimize messages by specifying attributes up front
     __slots__ = ["mtype", "name", "mid", "arguments"]
 
@@ -892,7 +883,7 @@ class Sensor(object):
 
     Subclasses will usually pass in a fixed sensor_type which should
     be one of the sensor type constants. The list params if set will
-    have its values formatter by the type formatter for the given
+    have its values formatted by the type formatter for the given
     sensor type.
 
     .. note::
@@ -1013,22 +1004,6 @@ class Sensor(object):
 
     ## @brief kattype Timestamp instance for encoding and decoding timestamps.
     TIMESTAMP_TYPE = Timestamp()
-
-    ## @var stype
-    # @brief Sensor type constant.
-
-    ## @var name
-    # @brief Sensor name.
-
-    ## @var description
-    # @brief String describing the sensor.
-
-    ## @var units
-    # @brief String contain the units for the sensor value.
-
-    ## @var params
-    # @brief List of strings containing the additional parameters (length and
-    #        interpretation are specific to the sensor type).
 
     def __init__(self, sensor_type, name, description=None, units=None,
                  params=None, default=None, initial_status=None):

--- a/katcp/server.py
+++ b/katcp/server.py
@@ -1505,9 +1505,6 @@ class DeviceServer(DeviceServerBase):
 
     SUPPORTED_PROTOCOL_MAJOR_VERSIONS = (4, 5)
 
-    ## @var log
-    # @brief DeviceLogger instance for sending log messages to the client.
-
     # * and ** magic fine here
     # pylint: disable-msg = W0142
 


### PR DESCRIPTION
The `@var` comments are duplicates of the description in the class docstrings, and sometimes provide inaccurate information, so removing them.  Also some further improvements to the `Server` class docstring to try to make the usage clearer.

Issue: #229