### PR TITLE
Pinned mock and coverage dependencies.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ commands =
     coverage html
     coverage report -m --skip-covered
 deps =
-    coverage
-    mock
+    coverage==5.0.3
+    mock==3.0.5
     nose
     nosexcover
 


### PR DESCRIPTION
This PR does the following:
- Pins testing dependencies due to the latest version of Mock causes python3.xx tests to fail: http://ci.camlab.kat.ac.za/job/katcp-multibranch/job/master/31/console

