### PR TITLE
Fixes to KATCP Types codecs w.r.t Python 2 and Python 3 

### DIFF
--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -274,12 +274,12 @@ class FakeInspectingClientManager(object):
         for s_name, s_info in sensor_infos.items():
             s_type = Sensor.parse_type(s_info[2])
             params = s_info[3:]
-            if s_info[2] == 'boolean':
-                params = []
-                for param in s_info[3:]:
-                    if param:
-                        params.append(native_str_to_bytes(param))
-            s_params = Sensor.parse_params(s_type, params)
+            #if s_info[2] == 'boolean':
+            #    params = []
+            #    for param in s_info[3:]:
+            #        if param:
+            #            params.append(native_str_to_bytes(param))
+            #s_params = Sensor.parse_params(s_type, params)
         self.fake_sensor_infos.update(sensor_infos)
         self._fic._interface_changed.set()
 

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -277,8 +277,7 @@ class FakeInspectingClientManager(object):
             if s_info[2] == 'boolean':
                 params = []
                 for param in s_info[3:]:
-                    if param:
-                        params.append(native_str_to_bytes(param))
+                    params.append(native_str_to_bytes(param))
             Sensor.parse_params(s_type, params)
         self.fake_sensor_infos.update(sensor_infos)
         self._fic._interface_changed.set()

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -274,12 +274,12 @@ class FakeInspectingClientManager(object):
         for s_name, s_info in sensor_infos.items():
             s_type = Sensor.parse_type(s_info[2])
             params = s_info[3:]
-            #if s_info[2] == 'boolean':
-            #    params = []
-            #    for param in s_info[3:]:
-            #        if param:
-            #            params.append(native_str_to_bytes(param))
-            #s_params = Sensor.parse_params(s_type, params)
+            if s_info[2] == 'boolean':
+                params = []
+                for param in s_info[3:]:
+                    if param:
+                        params.append(native_str_to_bytes(param))
+            Sensor.parse_params(s_type, params)
         self.fake_sensor_infos.update(sensor_infos)
         self._fic._interface_changed.set()
 

--- a/katcp/fake_clients.py
+++ b/katcp/fake_clients.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import, division, print_function
 from future import standard_library
+from future.utils import native_str_to_bytes
+
 standard_library.install_aliases()  # noqa: E402
 
 from builtins import object
@@ -271,7 +273,13 @@ class FakeInspectingClientManager(object):
         # Check sensor validity. parse_type() and parse_params should raise if not OK
         for s_name, s_info in sensor_infos.items():
             s_type = Sensor.parse_type(s_info[2])
-            s_params = Sensor.parse_params(s_type, s_info[3:])
+            params = s_info[3:]
+            if s_info[2] == 'boolean':
+                params = []
+                for param in s_info[3:]:
+                    if param:
+                        params.append(native_str_to_bytes(param))
+            s_params = Sensor.parse_params(s_type, params)
         self.fake_sensor_infos.update(sensor_infos)
         self._fic._interface_changed.set()
 

--- a/katcp/inspecting_client.py
+++ b/katcp/inspecting_client.py
@@ -6,6 +6,8 @@
 
 from __future__ import absolute_import, division, print_function
 from future import standard_library
+from future.utils import native_str_to_bytes
+
 standard_library.install_aliases()  # noqa: E402
 
 import copy
@@ -867,11 +869,17 @@ class InspectingClientAsync(object):
             sensor_info = self._sensors_index[name]
             obj = sensor_info.get('obj')
             if obj is None:
+                params = []
                 sensor_type = katcp.Sensor.parse_type(
                     sensor_info.get('sensor_type'))
+                for param in sensor_info.get('params'):
+                    if sensor_type == 2:
+                        params.append(native_str_to_bytes(param))
+                    else:
+                        params.append(param)
                 sensor_params = katcp.Sensor.parse_params(
                     sensor_type,
-                    sensor_info.get('params'))
+                    params)
                 obj = self.sensor_factory(
                     name=name,
                     sensor_type=sensor_type,

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -235,10 +235,10 @@ class Bool(KatcpType):
     encode = lambda self, value, major: value and b"1" or b"0"
 
     def decode(self, value, major):
-        if value not in (b"0", b"1", "0", "1"):
+        if value not in (b"0", b"1"):
             raise ValueError("Boolean value must be b'0' or b'1' but is '%s'."
                              % (value,))
-        return value == b"1" or value == "1"
+        return value == b"1"
 
 
 class Str(KatcpType):

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -394,6 +394,9 @@ class Address(KatcpType):
         return b"%s:%d" % (host, port) if port is not None else host
 
     def decode(self, value, major):
+        if is_text(value):
+            if not future.utils.PY2:
+                value = future.utils.native_str_to_bytes(value)
         if value.startswith(b"["):
             match = self.IPV6_RE.match(value)
         else:

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -286,7 +286,12 @@ class Str(KatcpType):
                 return str(value).encode('utf-8')
 
         def decode(self, value, major):
-            return value.decode('utf-8')
+            if is_bytes(value):
+                return value.decode('utf-8')
+            elif is_text(value):
+                return value
+            else:
+                return str(value)
 
 
 class Discrete(Str):

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -342,8 +342,8 @@ class Lru(KatcpType):
 
     ## @brief Mapping from LRU value constant to LRU value name.
     LRU_VALUES = {
-        LRU_NOMINAL: "nominal",
-        LRU_ERROR: "error",
+        LRU_NOMINAL: b"nominal",
+        LRU_ERROR: b"error",
     }
 
     # LRU_VALUES not found by pylint
@@ -358,6 +358,9 @@ class Lru(KatcpType):
         return Lru.LRU_VALUES[value]
 
     def decode(self, value, major):
+        if is_text(value):
+            if future.utils.PY3:
+                value = future.utils.native_str_to_bytes(value)
         if value not in Lru.LRU_CONSTANTS:
             raise ValueError("Lru value must be 'nominal' or 'error'.")
         return Lru.LRU_CONSTANTS[value]

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -441,7 +441,7 @@ class Address(KatcpType):
             if port is not None:
                 port = int(port)
             host = match.group('host')
-            if not future.utils.PY2:
+            if is_bytes(host):
                 host = host.decode('ascii')
             return host, port
 

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -394,8 +394,6 @@ class Address(KatcpType):
         return b"%s:%d" % (host, port) if port is not None else host
 
     def decode(self, value, major):
-        if not future.utils.PY2:
-            value = future.utils.native_str_to_bytes(value)
         if value.startswith(b"["):
             match = self.IPV6_RE.match(value)
         else:

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -342,8 +342,8 @@ class Lru(KatcpType):
 
     ## @brief Mapping from LRU value constant to LRU value name.
     LRU_VALUES = {
-        LRU_NOMINAL: b"nominal",
-        LRU_ERROR: b"error",
+        LRU_NOMINAL: "nominal",
+        LRU_ERROR: "error",
     }
 
     # LRU_VALUES not found by pylint
@@ -391,6 +391,8 @@ class Address(KatcpType):
         return b"%s:%d" % (host, port) if port is not None else host
 
     def decode(self, value, major):
+        if not future.utils.PY2:
+            value = future.utils.native_str_to_bytes(value)
         if value.startswith(b"["):
             match = self.IPV6_RE.match(value)
         else:

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -235,10 +235,10 @@ class Bool(KatcpType):
     encode = lambda self, value, major: value and b"1" or b"0"
 
     def decode(self, value, major):
-        if value not in (b"0", b"1"):
+        if value not in (b"0", b"1", "0", "1"):
             raise ValueError("Boolean value must be b'0' or b'1' but is '%s'."
                              % (value,))
-        return value == b"1"
+        return value == b"1" or value == "1"
 
 
 class Str(KatcpType):

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -369,7 +369,7 @@ class Lru(KatcpType):
 
         def decode(self, value, major):
             if is_text(value):
-                    value = future.utils.native_str_to_bytes(value)
+                value = future.utils.native_str_to_bytes(value)
             if value not in Lru.LRU_CONSTANTS:
                 raise ValueError("Lru value must be 'nominal' or 'error'.")
             return Lru.LRU_CONSTANTS[value]
@@ -401,7 +401,6 @@ class Address(KatcpType):
                 # IPv6
                 host = b"[%s]" % host
             return b"%s:%d" % (host, port) if port is not None else host
-
 
         def decode(self, value, major):
             if value.startswith(b"["):

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -40,7 +40,6 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
             'a-float': ('A float sensor', '', 'float', 1234.42),
             'a-boolean': ('A boolean sensor', '', 'boolean', '0'),
             'an-address': ('An address sensor', '', 'address', '127.0.0.1:8080'),
-            'a-lru': ('A LRU sensor', '', 'lru', 'nominal'),
         }
 
         yield self.fake_inspecting_client.connect()
@@ -105,16 +104,6 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 "type": Sensor.ADDRESS,
                 "description": "An address sensor",
                 "params": [("127.0.0.1", 8080)],
-            },
-        )
-        a_lru = yield self.fake_inspecting_client.future_get_sensor("a-lru")
-        self.assert_sensor_equal_description(
-            a_lru,
-            {
-                "name": "a-lru",
-                "type": Sensor.LRU,
-                "description": "A LRU sensor",
-                "params": [0]
             },
         )
 

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -36,10 +36,10 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
             'an-int': ('An integer sensor', 'things', 'integer', 0, 10),
             'a-string' : ('A string sensor', '', 'string'),
             'a-discrete': ('A discrete sensor', '', 'discrete', 'a', 'b', 'c'),
-            'a-timestamp': ('A timestamp sensor', '', 'timestamp', 1556928000),
-            'a-float': ('A float sensor', '', 'float', 1234.42),
-            'a-boolean': ('A boolean sensor', '', 'boolean', '0'),
-            'an-address': ('An address sensor', '', 'address', '127.0.0.1:8080'),
+            'a-timestamp': ('A timestamp sensor', '', 'timestamp'),
+            'a-float': ('A float sensor', '', 'float', -123.4, 123.4),
+            'a-boolean': ('A boolean sensor', '', 'boolean'),
+            'an-address': ('An address sensor', '', 'address'),
         }
 
         yield self.fake_inspecting_client.connect()
@@ -85,7 +85,6 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 "name": "a-timestamp",
                 "type": Sensor.TIMESTAMP,
                 "description": "A timestamp sensor",
-                "params": [1556928000],
             },
         )
         a_float = yield self.fake_inspecting_client.future_get_sensor("a-float")
@@ -95,7 +94,7 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 "name": "a-float",
                 "type": Sensor.FLOAT,
                 "description": "A float sensor",
-                "params": [1234.42],
+                "params": [-123.4, 123.4],
             },
         )
         a_boolean = yield self.fake_inspecting_client.future_get_sensor("a-boolean")
@@ -105,7 +104,6 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 "name": "a-boolean",
                 "type": Sensor.BOOLEAN,
                 "description": "A boolean sensor",
-                "params": [False],
             },
         )
         an_address = yield self.fake_inspecting_client.future_get_sensor("an-address")
@@ -115,7 +113,6 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 "name": "an-address",
                 "type": Sensor.ADDRESS,
                 "description": "An address sensor",
-                "params": [("127.0.0.1", 8080)],
             },
         )
 

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -39,7 +39,8 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
             'a-timestamp': ('A timestamp sensor', '', 'timestamp', 1556928000),
             'a-float': ('A float sensor', '', 'float', 1234.42),
             'a-boolean': ('A boolean sensor', '', 'boolean', '0'),
-            'an-address': ('An address sensor', '', 'address', '127.0.0.1'),
+            'an-address': ('An address sensor', '', 'address', '127.0.0.1:8080'),
+            'a-lru': ('A LRU sensor', '', 'lru', 'nominal'),
         }
 
         yield self.fake_inspecting_client.connect()
@@ -103,10 +104,19 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 name="an-address",
                 type=Sensor.ADDRESS,
                 description="An address sensor",
-                params=['127.0.0.1'],
+                params=[('127.0.0.1', 8080)],
             ),
         )
-
+        a_lru = yield self.fake_inspecting_client.future_get_sensor('a-lru')
+        self.assert_sensor_equal_description(
+            a_lru,
+            dict(
+                name="a-lru",
+                type=Sensor.LRU,
+                description="A LRU sensor",
+                params=[0],
+            ),
+        )
 
 
 class FakeHandlers(object):

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -39,6 +39,7 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
             'a-timestamp': ('A timestamp sensor', '', 'timestamp', 1556928000),
             'a-float': ('A float sensor', '', 'float', 1234.42),
             'a-boolean': ('A boolean sensor', '', 'boolean', '0'),
+            'an-address': ('An address sensor', '', 'address', '127.0.0.1'),
         }
 
         yield self.fake_inspecting_client.connect()
@@ -95,6 +96,18 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 params=[False],
             ),
         )
+        an_address = yield self.fake_inspecting_client.future_get_sensor('an-address')
+        self.assert_sensor_equal_description(
+            an_address,
+            dict(
+                name="an-address",
+                type=Sensor.ADDRESS,
+                description="An address sensor",
+                params=['127.0.0.1'],
+            ),
+        )
+
+
 
 class FakeHandlers(object):
     @request(Int(), Int())

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -49,13 +49,25 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
 
         an_int = yield self.fake_inspecting_client.future_get_sensor('an-int')
         s_description, s_units = sensor_info['an-int'][0:2]
-        self.assert_sensor_equal_description(an_int, dict(
-            name='an-int', type=Sensor.INTEGER, description='An integer sensor',
-            params=[0, 10]))
+        self.assert_sensor_equal_description(
+            an_int,
+            {
+                'name': 'an-int',
+                'type': Sensor.INTEGER,
+                'description': 'An integer sensor',
+                'params': [0, 10]
+            }
+        )
         a_string = yield self.fake_inspecting_client.future_get_sensor('a-string')
-        self.assert_sensor_equal_description(a_string, dict(
-            name='a-string', type=Sensor.STRING, description='A string sensor',
-            params=[]))
+        self.assert_sensor_equal_description(
+            a_string,
+            {
+                'name': 'a-string',
+                'type': Sensor.STRING,
+                'description': 'A string sensor',
+                'params': []
+            }
+        )
         a_discrete = yield self.fake_inspecting_client.future_get_sensor("a-discrete")
         self.assert_sensor_equal_description(
             a_discrete,

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -35,6 +35,8 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
         sensor_info = {
             'an-int': ('An integer sensor', 'things', 'integer', 0, 10),
             'a-string' : ('A string sensor', '', 'string'),
+            'a-discrete': ('A discrete sensor', '', 'discrete', 'a', 'b', 'c'),
+
         }
 
         yield self.fake_inspecting_client.connect()
@@ -51,6 +53,17 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
         self.assert_sensor_equal_description(a_string, dict(
             name='a-string', type=Sensor.STRING, description='A string sensor',
             params=[]))
+        a_discrete = yield self.fake_inspecting_client.future_get_sensor('a-discrete')
+        self.assert_sensor_equal_description(
+            a_discrete,
+            dict(
+                name="a-discrete",
+                type=Sensor.DISCRETE,
+                description="A discrete sensor",
+                params=["a", "b", "c"],
+            ),
+        )
+
 
 class FakeHandlers(object):
     @request(Int(), Int())

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -38,7 +38,7 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
             'a-discrete': ('A discrete sensor', '', 'discrete', 'a', 'b', 'c'),
             'a-timestamp': ('A timestamp sensor', '', 'timestamp', 1556928000),
             'a-float': ('A float sensor', '', 'float', 1234.42),
-            'a-boolean': ('A boolean sensor', '', 'boolean', '1'),
+            'a-boolean': ('A boolean sensor', '', 'boolean', '0'),
         }
 
         yield self.fake_inspecting_client.connect()
@@ -92,7 +92,7 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 name="a-boolean",
                 type=Sensor.BOOLEAN,
                 description="A boolean sensor",
-                params=['1'],
+                params=[False],
             ),
         )
 

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -36,7 +36,9 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
             'an-int': ('An integer sensor', 'things', 'integer', 0, 10),
             'a-string' : ('A string sensor', '', 'string'),
             'a-discrete': ('A discrete sensor', '', 'discrete', 'a', 'b', 'c'),
-
+            'a-timestamp': ('A timestamp sensor', '', 'timestamp', 1556928000),
+            'a-float': ('A float sensor', '', 'float', 1234.42),
+            'a-boolean': ('A boolean sensor', '', 'boolean', '1'),
         }
 
         yield self.fake_inspecting_client.connect()
@@ -63,7 +65,36 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
                 params=["a", "b", "c"],
             ),
         )
-
+        a_timestamp = yield self.fake_inspecting_client.future_get_sensor('a-timestamp')
+        self.assert_sensor_equal_description(
+            a_timestamp,
+            dict(
+                name="a-timestamp",
+                type=Sensor.TIMESTAMP,
+                description="A timestamp sensor",
+                params=[1556928000],
+            ),
+        )
+        a_float = yield self.fake_inspecting_client.future_get_sensor('a-float')
+        self.assert_sensor_equal_description(
+            a_float,
+            dict(
+                name="a-float",
+                type=Sensor.FLOAT,
+                description="A float sensor",
+                params=[1234.42],
+            ),
+        )
+        a_boolean = yield self.fake_inspecting_client.future_get_sensor('a-boolean')
+        self.assert_sensor_equal_description(
+            a_boolean,
+            dict(
+                name="a-boolean",
+                type=Sensor.BOOLEAN,
+                description="A boolean sensor",
+                params=['1'],
+            ),
+        )
 
 class FakeHandlers(object):
     @request(Int(), Int())

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -57,65 +57,60 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
         self.assert_sensor_equal_description(a_string, dict(
             name='a-string', type=Sensor.STRING, description='A string sensor',
             params=[]))
-        a_discrete = yield self.fake_inspecting_client.future_get_sensor('a-discrete')
+        a_discrete = yield self.fake_inspecting_client.future_get_sensor("a-discrete")
         self.assert_sensor_equal_description(
             a_discrete,
-            dict(
-                name="a-discrete",
-                type=Sensor.DISCRETE,
-                description="A discrete sensor",
-                params=["a", "b", "c"],
-            ),
+            {
+                "name": "a-discrete",
+                "type": Sensor.DISCRETE,
+                "description": "A discrete sensor",
+                "params": ["a", "b", "c"],
+            },
         )
-        a_timestamp = yield self.fake_inspecting_client.future_get_sensor('a-timestamp')
+        a_timestamp = yield self.fake_inspecting_client.future_get_sensor("a-timestamp")
         self.assert_sensor_equal_description(
             a_timestamp,
-            dict(
-                name="a-timestamp",
-                type=Sensor.TIMESTAMP,
-                description="A timestamp sensor",
-                params=[1556928000],
-            ),
+            {
+                "name": "a-timestamp",
+                "type": Sensor.TIMESTAMP,
+                "description": "A timestamp sensor",
+                "params": [1556928000],
+            },
         )
-        a_float = yield self.fake_inspecting_client.future_get_sensor('a-float')
+        a_float = yield self.fake_inspecting_client.future_get_sensor("a-float")
         self.assert_sensor_equal_description(
             a_float,
-            dict(
-                name="a-float",
-                type=Sensor.FLOAT,
-                description="A float sensor",
-                params=[1234.42],
-            ),
+            {
+                "name": "a-float",
+                "type": Sensor.FLOAT,
+                "description": "A float sensor",
+                "params": [1234.42],
+            },
         )
-        a_boolean = yield self.fake_inspecting_client.future_get_sensor('a-boolean')
+        a_boolean = yield self.fake_inspecting_client.future_get_sensor("a-boolean")
         self.assert_sensor_equal_description(
             a_boolean,
-            dict(
-                name="a-boolean",
-                type=Sensor.BOOLEAN,
-                description="A boolean sensor",
-                params=[False],
-            ),
+            {
+                "name": "a-boolean",
+                "type": Sensor.BOOLEAN,
+                "description": "A boolean sensor",
+                "params": [False],
+            },
         )
-        an_address = yield self.fake_inspecting_client.future_get_sensor('an-address')
+        an_address = yield self.fake_inspecting_client.future_get_sensor("an-address")
         self.assert_sensor_equal_description(
             an_address,
-            dict(
-                name="an-address",
-                type=Sensor.ADDRESS,
-                description="An address sensor",
-                params=[('127.0.0.1', 8080)],
-            ),
+            {
+                "name": "an-address",
+                "type": Sensor.ADDRESS,
+                "description": "An address sensor",
+                "params": [("127.0.0.1", 8080)],
+            },
         )
-        a_lru = yield self.fake_inspecting_client.future_get_sensor('a-lru')
+        a_lru = yield self.fake_inspecting_client.future_get_sensor("a-lru")
         self.assert_sensor_equal_description(
             a_lru,
-            dict(
-                name="a-lru",
-                type=Sensor.LRU,
-                description="A LRU sensor",
-                params=[0],
-            ),
+            {"name": "a-lru", "type": Sensor.LRU, "description": "A LRU sensor", "params": [0]},
         )
 
 

--- a/katcp/test/test_fake_clients.py
+++ b/katcp/test/test_fake_clients.py
@@ -110,9 +110,13 @@ class test_FakeInspectingClient(tornado.testing.AsyncTestCase,
         a_lru = yield self.fake_inspecting_client.future_get_sensor("a-lru")
         self.assert_sensor_equal_description(
             a_lru,
-            {"name": "a-lru", "type": Sensor.LRU, "description": "A LRU sensor", "params": [0]},
+            {
+                "name": "a-lru",
+                "type": Sensor.LRU,
+                "description": "A LRU sensor",
+                "params": [0]
+            },
         )
-
 
 class FakeHandlers(object):
     @request(Int(), Int())

--- a/katcp/test/test_kattypes.py
+++ b/katcp/test/test_kattypes.py
@@ -406,17 +406,20 @@ class TestStr(TestType):
             unicode_unpacked = u"adsasdasd"
             utf8_unpacked = "skr\xc3\xa4m"
             list_str_unpacked = "[1, 2.0, 'three', False]"
+            int_unpacked = 42
         else:
             bytes_unpacked = "adsasdasd"
-            unicode_unpacked = AttributeError
+            unicode_unpacked = "adsasdasd"
             utf8_unpacked = "skräm"
             list_str_unpacked = "[1, 2.0, 'three', False]"
+            int_unpacked = "42"
 
         self._unpack = [
             (basic, b"adsasdasd", bytes_unpacked),
             (basic, u"adsasdasd", unicode_unpacked),
             (basic, b"skr\xc3\xa4m", utf8_unpacked),
             (basic, b"[1, 2.0, 'three', False]", list_str_unpacked),
+            (basic, 42, int_unpacked),
             (basic, None, ValueError),
             (default, None, "something"),
             (default_optional, None, "something"),


### PR DESCRIPTION
Opening the PR for comments. This PR was created due address issues that were encountered with katcp during the Python 2 to Python 3 migration of [mkat-tango](https://github.com/ska-sa/mkat-tango)


This PR addresses issues with the encoding and decoding of sensor values w.r.t KATCP Types and Python 2 and Python 3 compatibility. 

- More tests were added for sensors that weren't tested
- This adds some conflicting Changes to functionality of  `Str` decode in Python 2 and Python 3

TODO
- [ ] Update CHANGES.md once PR is OKed 

PLEASE NOTE
 - There are currently issues with the CI job of this PR that is related to the code coverage.

JIRA: [P2M-17](https://skaafrica.atlassian.net/browse/P2M-17)
