### PR TITLE
Support for handling generator expressions in Discrete type

### DIFF
--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -306,7 +306,7 @@ class Discrete(Str):
         super(Discrete, self).__init__(**kwargs)
         self._case_insensitive = case_insensitive
         if not isinstance(values, list):
-            raise ValueError("%r values parsed should be a list, instead of %r" % (
+            raise ValueError("%r values passed should be a list, instead of %r" % (
                 values, type(values))
             )
         self._values = list(values)  # just to preserve ordering

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -305,8 +305,12 @@ class Discrete(Str):
     def __init__(self, values, case_insensitive=False, **kwargs):
         super(Discrete, self).__init__(**kwargs)
         self._case_insensitive = case_insensitive
+        if not isinstance(values, list):
+            raise ValueError("%r values parsed should be a list, instead of %r" % (
+                values, type(values))
+            )
         self._values = list(values)  # just to preserve ordering
-        self._valid_values = set(values)
+        self._valid_values = set(self._values)
         if self._case_insensitive:
             self._valid_values_lower = set([val.lower()
                                             for val in self._values])

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -305,10 +305,6 @@ class Discrete(Str):
     def __init__(self, values, case_insensitive=False, **kwargs):
         super(Discrete, self).__init__(**kwargs)
         self._case_insensitive = case_insensitive
-        if not isinstance(values, list):
-            raise ValueError("%r values passed should be a list, instead of %r" % (
-                values, type(values))
-            )
         self._values = list(values)  # just to preserve ordering
         self._valid_values = set(self._values)
         if self._case_insensitive:

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -294,7 +294,7 @@ class Discrete(Str):
 
     Parameters
     ----------
-    values : list of str
+    values : iterable of str
         List of the values the discrete type may accept.
     case_insensitive : bool
         Whether case-insensitive value matching should be used.

--- a/katcp/test/test_kattypes.py
+++ b/katcp/test/test_kattypes.py
@@ -186,6 +186,8 @@ class TestDiscrete(TestType):
         default_optional = Discrete(("VAL1", "VAL2"), default="VAL1",
                                     optional=True)
         case_insensitive = Discrete(("val1", "VAL2"), case_insensitive=True)
+        values = ('VAL{}'.format(i + 1) for i in range(2))
+        basic_generator = Discrete(values)
 
         self._pack = [
             (basic, "VAL1", b"VAL1"),
@@ -193,6 +195,11 @@ class TestDiscrete(TestType):
             (basic, "a", ValueError),
             (basic, "val1", ValueError),
             (basic, None, ValueError),
+            (basic_generator, "VAL1", b"VAL1"),
+            (basic_generator, "VAL2", b"VAL2"),
+            (basic_generator, "a", ValueError),
+            (basic_generator, "val1", ValueError),
+            (basic_generator, None, ValueError),
             (default, None, b"VAL1"),
             (default_optional, None, b"VAL1"),
             (optional, None, ValueError),
@@ -213,6 +220,11 @@ class TestDiscrete(TestType):
             (case_insensitive, b"vAl2", "vAl2"),
             (case_insensitive, b"a", ValueError),
         ]
+
+    def test_discrete_values(self):
+        values = ('VAL{}'.format(i + 1) for i in range(2))
+        basic = Discrete(values)
+        self.assertEqual(sorted(basic._values), sorted(basic._valid_values))
 
 
 class TestLru(TestType):


### PR DESCRIPTION
This PR does the following:

- [x] Added support for handling generator expressions in `Discrete` type. 

This fixes: https://github.com/ska-sa/katcore/blob/4db3ec97d140ba4917be68d2335660e7f06baa1d/katcore/sim_base.py#L161

JIRA: [MT-1543](https://skaafrica.atlassian.net/browse/MT-1543)