### PR TITLE
Bytes  status in get_sensor to str

### DIFF
--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -28,7 +28,7 @@ import tornado.locks
 import tornado.testing
 from _thread import get_ident
 from tornado.concurrent import Future as tornado_Future
-from future.utils import native_str_to_bytes, bytes_to_native_str  # noqa: E402
+from future.utils import native_str_to_bytes, bytes_to_native_str
 
 from katcp import client
 

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -28,7 +28,7 @@ import tornado.locks
 import tornado.testing
 from _thread import get_ident
 from tornado.concurrent import Future as tornado_Future
-from future.utils import native_str_to_bytes
+from future.utils import native_str_to_bytes, bytes_to_native_str  # noqa: E402
 
 from katcp import client
 
@@ -335,7 +335,7 @@ class BlockingTestClient(client.BlockingClient):
         except ValueError as e:
             self.test.fail("Could not convert value %r of sensor '%s' to type "
                            "%s: %s" % (value, sensorname, typestr, e))
-
+        status = bytes_to_native_str(status)
         self.test.assertTrue(status in Sensor.STATUSES.values(),
                              "Got invalid status value %r for sensor '%s'."
                              % (status, sensorname))

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ count = True
 ; D401 First line should be in imperative mood; try rephrasing
 ; W503: line break before binary operator (This is incompartible with Black,
 ;       See: https://black.readthedocs.io/en/stable/the_black_code_style.html#line-breaks-binary-operators)
-ignore = D401,W503
+ignore = D401,W503,E402
 exclude = *.egg/*,build,dist,__pycache__,.mypy_cache,.pytest_cache,__init__.py,docs/*.py
 ; C errors are not selected by default, so add them to your selection
 select = B,C,D,E,F,I,W


### PR DESCRIPTION
This PR ensures that status in the `get_sensor` is str and not bytes. 
This was picked up in the migration of katcore from python 2 to python 3.


related JIRA : https://skaafrica.atlassian.net/browse/P2M-31