### PR TITLE
only cast non bytes to str in params from assert_request_succeeds

### DIFF
--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -991,6 +991,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
 
         self.assertTrue(get_msgs.wait_number(6, timeout=4.75/32.))
         self.client.assert_request_succeeds("sensor-sampling", "an.int", "none")
+        self.client.assert_request_succeeds("log-level", b"debug", args_echo=True)
         # Wait for reply to above request
         get_msgs.wait_number(7)
         msgs = get_msgs()
@@ -1002,6 +1003,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self._assert_msgs_equal(others, [
             r"!sensor-sampling[1] ok an.int period %s" % (1/32.),
             r"!sensor-sampling[2] ok an.int none",
+            r"!log-level[3] ok debug"
         ])
 
         self.assertEqual(updates[0].arguments[1:],

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -8,7 +8,11 @@
 
 from __future__ import absolute_import, division, print_function
 from future import standard_library
+
 standard_library.install_aliases()  # noqa: E402
+
+from .compat import is_bytes
+
 
 import functools
 import logging
@@ -792,7 +796,12 @@ class BlockingTestClient(client.BlockingClient):
         informs_args_equal = kwargs.get("informs_args_equal")
 
         if args_echo:
-            args_equal = [str(p) for p in params]
+            args_equal = []
+            for p in params:
+                if is_bytes(p):
+                    args_equal.append(p)
+                else:
+                    args_equal.append(str(p))
 
         if args_equal is not None:
             msg = ("Expected reply to request '%s' called with parameters %r "


### PR DESCRIPTION
@ajoubertza I am currently migrating the katcore tests and I ran into something that appears to be another bug in katcp-python testutils for python2 and python3 .

It occurs in the testutils `assert_request_succeeds` method I added a line that exercises it for the case of passing an argument through that is a byte and similar to the tests found in katcore see https://github.com/ska-sa/katcore/blob/3b8f8f42192a47ed7e52f2f504787876ed6ed0f2/katcore/test/test_swcomp_base.py#L143

The PR is not a fix but a work around and aid to a potential fix as this bytes in the params might have to be caught earlier. 

Could you provide your input on this?

