### PR TITLE
check if arg is bytes and then cast to str.

### DIFF
--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -1014,7 +1014,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self.server.ioloop.add_callback(self.server.clear_strategies, client_conn)
         self.server.sync_with_ioloop()
         self.client.assert_request_succeeds("sensor-sampling", "an.int",
-                                            args_equal=[b"an.int", b"none"])
+                                            args_equal=["an.int", "none"])
 
         # Check that we did not accidentally clobber the strategy datastructure
         # in the proccess

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -38,6 +38,7 @@ from .kattypes import (Bool, Discrete, Float, Int, Str, concurrent_reply,
                        request, request_timeout_hint, return_reply)
 from .object_proxies import ObjectWrapper
 from .server import ClientConnection, DeviceServer, FailReply
+from .compat import is_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -782,8 +783,11 @@ class BlockingTestClient(client.BlockingClient):
                                         "(with no error message)")))
         self.test.assertTrue(reply.reply_ok(), msg)
 
-        args = reply.arguments[1:]
-
+        args = []
+        for arg in reply.arguments[1:]:
+            if is_bytes(arg):
+                arg = bytes_to_native_str(arg)
+            args.append(arg)
         args_echo = kwargs.get("args_echo", False)
         args_equal = kwargs.get("args_equal")
         args_in = kwargs.get("args_in")


### PR DESCRIPTION
This is an alternate approach to addressing the issue where byte strings are present in the arguments and causes issues down the line  where we do comparisons in the `assert_request_succeeds` method.

The other approach is https://github.com/ska-sa/katcp-python/pull/241 



related JIRA: https://skaafrica.atlassian.net/browse/P2M-34 