### PR TITLE
use `bytes_to_native_str` inside `get_sensor` when sensortype is `str`

### DIFF
--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -329,6 +329,9 @@ class BlockingTestClient(client.BlockingClient):
             if sensortype == bool:
                 typestr = "%r and then %r" % (int, bool)
                 value = bool(int(value))
+            elif sensortype == str:
+                typestr = "%r" % sensortype
+                value = bytes_to_native_str(value)
             else:
                 typestr = "%r" % sensortype
                 value = sensortype(value)


### PR DESCRIPTION
This PR addresses issues in `get_sensor` in python 3 when no sensortype is supplied and the value is not a `str`.
It returns the value as quoted byte string. 
e.g if the value is a float that is `3.213` and the sensortype argument is `str` it will be retrieved from the katcp message arguments as `b'3.123'` then the `str` function will be applied to it and it will return as `"b'3.213'"`


This PR fixes that. 

related JIRA: https://skaafrica.atlassian.net/browse/P2M-37