### PR TITLE
allow bytes and strings in test sensor list comparison of sensors.

### DIFF
--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -1049,9 +1049,14 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self.client.test_sensor_list(byte_sensors)
 
         str_sensors = {("a.discrete", "A Discrete.", "", "discrete", "one", "two", "three"),
-                            ("a.float", b"A Float.", "", "float", "-123.4", "123.4"),
-                            ("an.int", b"An Integer.", "count", "integer", "-5", "5")}
+                            ("a.float", "A Float.", "", "float", "-123.4", "123.4"),
+                            ("an.int", "An Integer.", "count", "integer", "-5", "5")}
         self.client.test_sensor_list(str_sensors)
+
+        mix_sensors = {("a.discrete", "A Discrete.", "", "discrete", b"one", b"two", b"three"),
+                            ("a.float", b"A Float.", "", b"float", "-123.4", "123.4"),
+                            ("an.int", b"An Integer.", "count", "integer", "-5", b"5")}
+        self.client.test_sensor_list(mix_sensors)
 
     def test_assert_request_succeeds(self):
         """Test exercises assert_request_succeeds"""

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -1047,16 +1047,19 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
                             (b"a.float", b"A Float.", b"", b"float", b"-123.4", b"123.4"),
                             (b"an.int", b"An Integer.", b"count", b"integer", b"-5", b"5")}
         self.client.test_sensor_list(byte_sensors)
+        self.client.test_sensor_list(byte_sensors, ignore_descriptions=True)
 
         str_sensors = {("a.discrete", "A Discrete.", "", "discrete", "one", "two", "three"),
                             ("a.float", "A Float.", "", "float", "-123.4", "123.4"),
                             ("an.int", "An Integer.", "count", "integer", "-5", "5")}
         self.client.test_sensor_list(str_sensors)
+        self.client.test_sensor_list(str_sensors, ignore_descriptions=True)
 
         mix_sensors = {("a.discrete", "A Discrete.", "", "discrete", b"one", b"two", b"three"),
                             ("a.float", b"A Float.", "", b"float", "-123.4", "123.4"),
                             ("an.int", b"An Integer.", "count", "integer", "-5", b"5")}
         self.client.test_sensor_list(mix_sensors)
+        self.client.test_sensor_list(mix_sensors, ignore_descriptions=True)
 
     def test_assert_request_succeeds(self):
         """Test exercises assert_request_succeeds"""

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -1043,11 +1043,15 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
 
     def test_test_sensor_list(self):
         """Test that exercises test_sensor_list"""
-        expected_sensors = {(b"a.discrete", b"A Discrete.", b"", b"discrete", b"one", b"two", b"three"),
+        byte_sensors = {(b"a.discrete", b"A Discrete.", b"", b"discrete", b"one", b"two", b"three"),
                             (b"a.float", b"A Float.", b"", b"float", b"-123.4", b"123.4"),
                             (b"an.int", b"An Integer.", b"count", b"integer", b"-5", b"5")}
+        self.client.test_sensor_list(byte_sensors)
 
-        self.client.test_sensor_list(expected_sensors)
+        str_sensors = {("a.discrete", "A Discrete.", "", "discrete", "one", "two", "three"),
+                            ("a.float", b"A Float.", "", "float", "-123.4", "123.4"),
+                            ("an.int", b"An Integer.", "count", "integer", "-5", "5")}
+        self.client.test_sensor_list(str_sensors)
 
     def test_assert_request_succeeds(self):
         """Test exercises assert_request_succeeds"""

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -1066,6 +1066,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         }
         self.client.test_sensor_list(mix_sensors)
         self.client.test_sensor_list(mix_sensors, ignore_descriptions=True)
+
     def test_assert_request_succeeds(self):
         """Test exercises assert_request_succeeds"""
 

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -1041,6 +1041,14 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
                 error_equals="Unknown sensor name: an.nonexistentsensor."
             )
 
+    def test_test_sensor_list(self):
+        """Test that exercises test_sensor_list"""
+        expected_sensors = {(b"a.discrete", b"A Discrete.", b"", b"discrete", b"one", b"two", b"three"),
+                            (b"a.float", b"A Float.", b"", b"float", b"-123.4", b"123.4"),
+                            (b"an.int", b"An Integer.", b"count", b"integer", b"-5", b"5")}
+
+        self.client.test_sensor_list(expected_sensors)
+
     def test_assert_request_succeeds(self):
         """Test exercises assert_request_succeeds"""
 

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -1043,24 +1043,29 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
 
     def test_test_sensor_list(self):
         """Test that exercises test_sensor_list"""
-        byte_sensors = {(b"a.discrete", b"A Discrete.", b"", b"discrete", b"one", b"two", b"three"),
-                            (b"a.float", b"A Float.", b"", b"float", b"-123.4", b"123.4"),
-                            (b"an.int", b"An Integer.", b"count", b"integer", b"-5", b"5")}
+        byte_sensors = {
+            (b"a.discrete", b"A Discrete.", b"", b"discrete", b"one", b"two", b"three"),
+            (b"a.float", b"A Float.", b"", b"float", b"-123.4", b"123.4"),
+            (b"an.int", b"An Integer.", b"count", b"integer", b"-5", b"5"),
+        }
         self.client.test_sensor_list(byte_sensors)
         self.client.test_sensor_list(byte_sensors, ignore_descriptions=True)
 
-        str_sensors = {("a.discrete", "A Discrete.", "", "discrete", "one", "two", "three"),
-                            ("a.float", "A Float.", "", "float", "-123.4", "123.4"),
-                            ("an.int", "An Integer.", "count", "integer", "-5", "5")}
+        str_sensors = {
+            ("a.discrete", "A Discrete.", "", "discrete", "one", "two", "three"),
+            ("a.float", "A Float.", "", "float", "-123.4", "123.4"),
+            ("an.int", "An Integer.", "count", "integer", "-5", "5"),
+        }
         self.client.test_sensor_list(str_sensors)
         self.client.test_sensor_list(str_sensors, ignore_descriptions=True)
 
-        mix_sensors = {("a.discrete", "A Discrete.", "", "discrete", b"one", b"two", b"three"),
-                            ("a.float", b"A Float.", "", b"float", "-123.4", "123.4"),
-                            ("an.int", b"An Integer.", "count", "integer", "-5", b"5")}
+        mix_sensors = {
+            ("a.discrete", "A Discrete.", "", "discrete", b"one", b"two", b"three"),
+            ("a.float", b"A Float.", "", b"float", "-123.4", "123.4"),
+            ("an.int", b"An Integer.", "count", "integer", "-5", b"5"),
+        }
         self.client.test_sensor_list(mix_sensors)
         self.client.test_sensor_list(mix_sensors, ignore_descriptions=True)
-
     def test_assert_request_succeeds(self):
         """Test exercises assert_request_succeeds"""
 

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -642,9 +642,21 @@ class BlockingTestClient(client.BlockingClient):
         """
         def sensortuple(name, description, units, stype, *params):
             # ensure float params reduced to the same format
+            native_str_params = []
             if stype == "float":
                 params = ["%g" % float(p) for p in params]
-            return (name, description, units, stype) + tuple(params)
+            for param in params:
+                if is_bytes(param):
+                    str_param = ensure_native_str(param)
+                    native_str_params.append(str_param)
+                else:
+                    native_str_params.append(param)
+            return (
+                ensure_native_str(name),
+                ensure_native_str(description),
+                ensure_native_str(units),
+                ensure_native_str(stype),
+            ) + tuple(native_str_params)
 
         reply, informs = self.blocking_request(Message.request("sensor-list"))
 


### PR DESCRIPTION
This PR adds a test and functionality that allows bytes and strings to work with `test_sensor_list`.


