### PR TITLE
Correct handling of floats test sensor list

### DIFF
--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -670,6 +670,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"#log fatal", r"root fatal-msg"),
         ]
         self._assert_msgs_like(get_msgs(min_number=len(expected_msgs)), expected_msgs)
+
     def test_standard_requests_with_ids(self):
         """Test standard request and replies with message ids."""
         get_msgs = self.client.message_recorder(

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -637,7 +637,8 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three", ""),
             (r"#sensor-list a.float A\_Float. \@ float -123.4 123.4", ""),
             (
-                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0"
+                r" 123.0",
                 "",
             ),
             (r"#sensor-list an.int An\_Integer. count integer -5 5", ""),

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -634,15 +634,17 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"!version-list ok 3", ""),
             (r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three", ""),
             (r"#sensor-list a.float A\_Float. \@ float -123.4 123.4", ""),
+            (r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0", ""),
             (r"#sensor-list an.int An\_Integer. count integer -5 5", ""),
-            (r"!sensor-list ok 3", ""),
+            (r"!sensor-list ok 4", ""),
             (r"#sensor-list an.int An\_Integer. count integer -5 5", ""),
             (r"!sensor-list ok 1", ""),
             (r"!sensor-list fail", ""),
             (r"#sensor-value 12345.000000 1 a.discrete nominal one", ""),
             (r"#sensor-value 12345.000000 1 a.float nominal 12.0", ""),
+            (r"#sensor-value 12345.000000 1 a.floatwithzero nominal 12.0", ""),
             (r"#sensor-value 12345.000000 1 an.int nominal 3", ""),
-            (r"!sensor-value ok 3", ""),
+            (r"!sensor-value ok 4", ""),
             (r"#sensor-value 12345.000000 1 an.int nominal 3", ""),
             (r"!sensor-value ok 1", ""),
             (r"!sensor-value fail", ""),
@@ -754,15 +756,17 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"!version-list[10] ok 3", ""),
             (r"#sensor-list[11] a.discrete A\_Discrete. \@ discrete one two three", ""),
             (r"#sensor-list[11] a.float A\_Float. \@ float -123.4 123.4", ""),
+            (r"#sensor-list[11] a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0", ""),
             (r"#sensor-list[11] an.int An\_Integer. count integer -5 5", ""),
-            (r"!sensor-list[11] ok 3", ""),
+            (r"!sensor-list[11] ok 4", ""),
             (r"#sensor-list[12] an.int An\_Integer. count integer -5 5", ""),
             (r"!sensor-list[12] ok 1", ""),
             (r"!sensor-list[13] fail", ""),
             (r"#sensor-value[14] 12345.000000 1 a.discrete nominal one", ""),
             (r"#sensor-value[14] 12345.000000 1 a.float nominal 12", ""),
+            (r"#sensor-value[14] 12345.000000 1 a.floatwithzero nominal 12", ""),
             (r"#sensor-value[14] 12345.000000 1 an.int nominal 3", ""),
-            (r"!sensor-value[14] ok 3", ""),
+            (r"!sensor-value[14] ok 4", ""),
             (r"#sensor-value[15] 12345.000000 1 an.int nominal 3", ""),
             (r"!sensor-value[15] ok 1", ""),
             (r"!sensor-value[16] fail", ""),
@@ -790,8 +794,9 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self._assert_msgs_equal(informs + [reply], [
             r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
             r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
+            r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
             r"#sensor-list an.int An\_Integer. count integer -5 5",
-            r"!sensor-list ok 3",
+            r"!sensor-list ok 4",
         ])
 
         reply, informs = self.client.blocking_request(katcp.Message.request(
@@ -799,8 +804,9 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self._assert_msgs_equal(informs + [reply], [
             r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
             r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
+            r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
             r"#sensor-list an.int An\_Integer. count integer -5 5",
-            r"!sensor-list ok 3",
+            r"!sensor-list ok 4",
         ])
 
         reply, informs = self.client.blocking_request(katcp.Message.request(
@@ -815,8 +821,9 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self._assert_msgs_equal(informs + [reply], [
             r'#sensor-value 12345.000000 1 a.discrete nominal one',
             r"#sensor-value 12345.000000 1 a.float nominal 12.0",
+            r"#sensor-value 12345.000000 1 a.floatwithzero nominal 12.0",
             r"#sensor-value 12345.000000 1 an.int nominal 3",
-            r"!sensor-value ok 3",
+            r"!sensor-value ok 4",
         ])
 
         reply, informs = self.client.blocking_request(katcp.Message.request(
@@ -824,8 +831,9 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self._assert_msgs_equal(informs + [reply], [
             r'#sensor-value 12345.000000 1 a.discrete nominal one',
             r'#sensor-value 12345.000000 1 a.float nominal 12.0',
+            r'#sensor-value 12345.000000 1 a.floatwithzero nominal 12.0',
             r"#sensor-value 12345.000000 1 an.int nominal 3",
-            r"!sensor-value ok 3",
+            r"!sensor-value ok 4",
         ])
 
         reply, informs = self.client.blocking_request(katcp.Message.request(
@@ -1046,6 +1054,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         byte_sensors = {
             (b"a.discrete", b"A Discrete.", b"", b"discrete", b"one", b"two", b"three"),
             (b"a.float", b"A Float.", b"", b"float", b"-123.4", b"123.4"),
+            (b"a.floatwithzero", b"A Float with zero.", b"", b"float", b"-123.0", b"123.0"),
             (b"an.int", b"An Integer.", b"count", b"integer", b"-5", b"5"),
         }
         self.client.test_sensor_list(byte_sensors)
@@ -1054,6 +1063,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         str_sensors = {
             ("a.discrete", "A Discrete.", "", "discrete", "one", "two", "three"),
             ("a.float", "A Float.", "", "float", "-123.4", "123.4"),
+            ("a.floatwithzero", "A Float with zero.", "", "float", "-123.0", "123.0"),
             ("an.int", "An Integer.", "count", "integer", "-5", "5"),
         }
         self.client.test_sensor_list(str_sensors)
@@ -1062,6 +1072,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         mix_sensors = {
             ("a.discrete", "A Discrete.", "", "discrete", b"one", b"two", b"three"),
             ("a.float", b"A Float.", "", b"float", "-123.4", "123.4"),
+            (b"a.floatwithzero", "A Float with zero.", b"", "float", b"-123.0", "123.0"),
             ("an.int", b"An Integer.", "count", "integer", "-5", b"5"),
         }
         self.client.test_sensor_list(mix_sensors)

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -730,7 +730,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"!log-level[5] fail Unknown\_logging\_level\_name\_'unknown'", ""),
             (
                 r"#help[6] cancel-slow-command Cancel\_slow\_command\_request,\_"
-                "resulting\_in\_it\_replying\_immediately",
+                r"resulting\_in\_it\_replying\_immediately",
                 "",
             ),
             (r"#help[6] client-list", ""),

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -595,7 +595,6 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             self.server.log.error("error-msg")
             self.server.log.fatal("fatal-msg")
         self.server.ioloop.add_callback(tst)
-
         self.assertEqual(self.server.restart_queue.get_nowait(), self.server)
         expected_msgs = [
             (r"!watchdog ok", ""),
@@ -603,8 +602,11 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"!log-level ok warn", ""),
             (r"!log-level ok trace", ""),
             (r"!log-level fail Unknown\_logging\_level\_name\_'unknown'", ""),
-            (r"#help cancel-slow-command Cancel\_slow\_command\_request,\_"
-             r"resulting\_in\_it\_replying\_immediately", ""),
+            (
+                r"#help cancel-slow-command Cancel\_slow\_command\_request,\_"
+                r"resulting\_in\_it\_replying\_immediately",
+                "",
+            ),
             (r"#help client-list", ""),
             (r"#help decorated", ""),
             (r"#help decorated-return-exception", ""),
@@ -634,7 +636,10 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"!version-list ok 3", ""),
             (r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three", ""),
             (r"#sensor-list a.float A\_Float. \@ float -123.4 123.4", ""),
-            (r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0", ""),
+            (
+                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                "",
+            ),
             (r"#sensor-list an.int An\_Integer. count integer -5 5", ""),
             (r"!sensor-list ok 4", ""),
             (r"#sensor-list an.int An\_Integer. count integer -5 5", ""),
@@ -663,9 +668,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"#log error", r"root error-msg"),
             (r"#log fatal", r"root fatal-msg"),
         ]
-        self._assert_msgs_like(get_msgs(min_number=len(expected_msgs)),
-                               expected_msgs)
-
+        self._assert_msgs_like(get_msgs(min_number=len(expected_msgs)), expected_msgs)
     def test_standard_requests_with_ids(self):
         """Test standard request and replies with message ids."""
         get_msgs = self.client.message_recorder(
@@ -716,6 +719,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             self.server.log.warn("warn-msg")
             self.server.log.error("error-msg")
             self.server.log.fatal("fatal-msg")
+
         self.server.ioloop.add_callback(tst)
 
         expected_msgs = [
@@ -723,10 +727,12 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"!restart[2] ok", ""),
             (r"!log-level[3] ok warn", ""),
             (r"!log-level[4] ok trace", ""),
-            (r"!log-level[5] fail Unknown\_logging\_level\_name\_'unknown'",
-             ""),
-            (r"#help[6] cancel-slow-command Cancel\_slow\_command\_request,\_"
-             "resulting\_in\_it\_replying\_immediately", ""),
+            (r"!log-level[5] fail Unknown\_logging\_level\_name\_'unknown'", ""),
+            (
+                r"#help[6] cancel-slow-command Cancel\_slow\_command\_request,\_"
+                "resulting\_in\_it\_replying\_immediately",
+                "",
+            ),
             (r"#help[6] client-list", ""),
             (r"#help[6] decorated", ""),
             (r"#help[6] decorated-return-exception", ""),
@@ -756,7 +762,10 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"!version-list[10] ok 3", ""),
             (r"#sensor-list[11] a.discrete A\_Discrete. \@ discrete one two three", ""),
             (r"#sensor-list[11] a.float A\_Float. \@ float -123.4 123.4", ""),
-            (r"#sensor-list[11] a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0", ""),
+            (
+                r"#sensor-list[11] a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                "",
+            ),
             (r"#sensor-list[11] an.int An\_Integer. count integer -5 5", ""),
             (r"!sensor-list[11] ok 4", ""),
             (r"#sensor-list[12] an.int An\_Integer. count integer -5 5", ""),
@@ -1054,12 +1063,18 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         byte_sensors = {
             (b"a.discrete", b"A Discrete.", b"", b"discrete", b"one", b"two", b"three"),
             (b"a.float", b"A Float.", b"", b"float", b"-123.4", b"123.4"),
-            (b"a.floatwithzero", b"A Float with zero.", b"", b"float", b"-123.0", b"123.0"),
+            (
+                b"a.floatwithzero",
+                b"A Float with zero.",
+                b"",
+                b"float",
+                b"-123.0",
+                b"123.0",
+            ),
             (b"an.int", b"An Integer.", b"count", b"integer", b"-5", b"5"),
         }
         self.client.test_sensor_list(byte_sensors)
         self.client.test_sensor_list(byte_sensors, ignore_descriptions=True)
-
         str_sensors = {
             ("a.discrete", "A Discrete.", "", "discrete", "one", "two", "three"),
             ("a.float", "A Float.", "", "float", "-123.4", "123.4"),

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -763,7 +763,8 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             (r"#sensor-list[11] a.discrete A\_Discrete. \@ discrete one two three", ""),
             (r"#sensor-list[11] a.float A\_Float. \@ float -123.4 123.4", ""),
             (
-                r"#sensor-list[11] a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                r"#sensor-list[11] a.floatwithzero A\_Float\_with\_zero. \@ float -123.0"
+                r" 123.0",
                 "",
             ),
             (r"#sensor-list[11] an.int An\_Integer. count integer -5 5", ""),

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -644,7 +644,7 @@ class BlockingTestClient(client.BlockingClient):
             # ensure float params reduced to the same format
             native_str_params = []
             if stype == "float":
-                params = ["%g" % float(p) for p in params]
+                params = ["%r" % float(p) for p in params]
             for param in params:
                 if is_bytes(param):
                     str_param = ensure_native_str(param)

--- a/katcp/testutils.py
+++ b/katcp/testutils.py
@@ -1045,6 +1045,10 @@ class DeviceTestServer(DeviceServer):
             Sensor.FLOAT, "a.float", "A Float.", "",
             [-123.4, 123.4],
             timestamp=12345, status=Sensor.NOMINAL, value=12))
+        self.add_sensor(DeviceTestSensor(
+            Sensor.FLOAT, "a.floatwithzero", "A Float with zero.", "",
+            [-123.0, 123.0],
+            timestamp=12345, status=Sensor.NOMINAL, value=12))
 
     def request_new_command(self, req, msg):
         """A new command."""


### PR DESCRIPTION
This PR corrects the handling of floats in the`sensor_tuple` helper function used in `test_sensor_list`.

- This adds a new float sensor with a zero to the right of the decimal point 
- Tests where the sensor is tested correctly inside `test_sensor_list`
