### PR TITLE
ran black on test_server

### DIFF
--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -166,7 +166,7 @@ class test_ClientRequestConnection(unittest.TestCase):
 class TestDeviceServerV4(unittest.TestCase, TestUtilMixin):
     class DeviceTestServerV4(DeviceTestServer):
         ## Protocol versions and flags for a katcp v4 server
-        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, set([katcp.ProtocolFlags.MULTI_CLIENT]))
+        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, {katcp.ProtocolFlags.MULTI_CLIENT})
 
     def setUp(self):
         self.server = self.DeviceTestServerV4("", 0)
@@ -274,7 +274,7 @@ class TestDeviceServerV4(unittest.TestCase, TestUtilMixin):
 class TestDeviceServerV4Async(TestDeviceServerV4):
     class DeviceTestServerV4(DeviceTestServer):
         ## Protocol versions and flags for a katcp v4 server
-        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, set([katcp.ProtocolFlags.MULTI_CLIENT]))
+        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, {katcp.ProtocolFlags.MULTI_CLIENT})
 
         def __init__(self, *args, **kwargs):
             super(TestDeviceServerV4Async.DeviceTestServerV4, self).__init__(
@@ -288,7 +288,7 @@ class TestVersionCompatibility(unittest.TestCase):
         class DeviceTestServerWrong(DeviceTestServer):
             ## Protocol versions and flags for a katcp v4 server
             PROTOCOL_INFO = katcp.ProtocolFlags(
-                3, 0, set([katcp.ProtocolFlags.MULTI_CLIENT])
+                3, 0, {katcp.ProtocolFlags.MULTI_CLIENT}
             )
 
         # Only major versions 4 and 5 are supported
@@ -413,7 +413,7 @@ class test_DeviceServer51(test_DeviceServer):
         self.server.set_concurrency_options(thread_safe=False, handler_thread=False)
 
     def test_excluded_default_handlers(self):
-        pass  #  No excluded default handlers for v5.1 as of yet
+        pass  # No excluded default handlers for v5.1 as of yet
 
     def test_request_timeout_hint(self):
         req = mock_req("request-timeout-hint")
@@ -822,7 +822,8 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             [
                 r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
                 r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
-                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0"
+                r" 123.0",
                 r"#sensor-list an.int An\_Integer. count integer -5 5",
                 r"!sensor-list ok 4",
             ],
@@ -836,7 +837,8 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             [
                 r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
                 r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
-                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0"
+                r" 123.0",
                 r"#sensor-list an.int An\_Integer. count integer -5 5",
                 r"!sensor-list ok 4",
             ],

--- a/katcp/test/test_server.py
+++ b/katcp/test/test_server.py
@@ -7,6 +7,7 @@
 """Tests for the server module."""
 from __future__ import absolute_import, division, print_function
 from future import standard_library
+
 standard_library.install_aliases()  # noqa: E402
 
 import gc
@@ -31,11 +32,18 @@ from tornado import gen
 import katcp
 from katcp import __version__, kattypes
 from katcp.core import FailReply
-from katcp.testutils import (AsyncDeviceTestServer, BlockingTestClient,
-                             ClientConnectionTest, DeviceTestServer,
-                             TestLogHandler, TestUtilMixin, WaitingMock,
-                             handle_mock_req, mock_req,
-                             start_thread_with_cleanup)
+from katcp.testutils import (
+    AsyncDeviceTestServer,
+    BlockingTestClient,
+    ClientConnectionTest,
+    DeviceTestServer,
+    TestLogHandler,
+    TestUtilMixin,
+    WaitingMock,
+    handle_mock_req,
+    mock_req,
+    start_thread_with_cleanup,
+)
 
 
 log_handler = TestLogHandler()
@@ -51,18 +59,18 @@ class test_ClientConnection(unittest.TestCase):
         # server methods
 
         # Check standard async inform
-        server = mock.Mock(spec=katcp.server.KATCPServer(mock.Mock(), '', 0))
-        raw_socket = 'raw_socket'
+        server = mock.Mock(spec=katcp.server.KATCPServer(mock.Mock(), "", 0))
+        raw_socket = "raw_socket"
         DUT = katcp.server.ClientConnection(server, raw_socket)
-        inf_arg = katcp.Message.inform('infarg')
+        inf_arg = katcp.Message.inform("infarg")
         DUT.inform(inf_arg)
         server.send_message.assert_called_once_with(raw_socket, inf_arg)
 
         # Check reply-inform
         server.send_message.reset_mock()
-        mid = b'5'
-        rif_req = katcp.Message.request('rif', mid=mid)
-        rif_inf = katcp.Message.inform('rif')
+        mid = b"5"
+        rif_req = katcp.Message.request("rif", mid=mid)
+        rif_inf = katcp.Message.inform("rif")
         # Double-check that the mid's don't match before the call
         self.assertNotEqual(rif_inf.mid, mid)
         DUT.reply_inform(rif_inf, rif_req)
@@ -73,16 +81,16 @@ class test_ClientConnection(unittest.TestCase):
 
         # Check that an assert is raised the original request and inform names don't match
         server.send_message.reset_mock()
-        rif_req = katcp.Message.request('riffy')
+        rif_req = katcp.Message.request("riffy")
         with self.assertRaises(Exception):
             DUT.reply_inform(rif_inf, rif_req)
         self.assertFalse(server.send_message.called)
 
         # Check reply
         server.send_message.reset_mock()
-        mid = b'7'
-        rep_req = katcp.Message.request('rep-req', mid=mid)
-        rep_rep = katcp.Message.reply('rep-req')
+        mid = b"7"
+        rep_req = katcp.Message.request("rep-req", mid=mid)
+        rep_rep = katcp.Message.reply("rep-req")
         # Double-check that the mid's don't match before the call
         self.assertNotEqual(rep_rep.mid, mid)
         DUT.reply(rep_rep, rep_req)
@@ -93,49 +101,50 @@ class test_ClientConnection(unittest.TestCase):
 
         # Check that an assert is raised the original request and reply names don't match
         server.send_message.reset_mock()
-        rep_rep = katcp.Message.request('reppy')
+        rep_rep = katcp.Message.request("reppy")
         with self.assertRaises(Exception):
             DUT.reply(rep_rep, rep_req)
         self.assertFalse(server.send_message.called)
 
         # Check that mass_inform works
-        DUT.mass_inform(katcp.Message.inform('blahh'))
-        server.mass_send_message.assert_called_once_with(katcp.Message.inform('blahh'))
+        DUT.mass_inform(katcp.Message.inform("blahh"))
+        server.mass_send_message.assert_called_once_with(katcp.Message.inform("blahh"))
+
 
 class test_ClientRequestConnection(unittest.TestCase):
     def setUp(self):
         self.client_connection = mock.Mock()
-        self.req_msg = katcp.Message.request(
-            'test-request', 'parm1', 'parm2', mid=42)
+        self.req_msg = katcp.Message.request("test-request", "parm1", "parm2", mid=42)
         self.DUT = katcp.server.ClientRequestConnection(
-            self.client_connection, self.req_msg)
+            self.client_connection, self.req_msg
+        )
 
     def test_inform(self):
-        arguments = (b'inf1', b'inf2')
+        arguments = (b"inf1", b"inf2")
         self.DUT.inform(*arguments)
         self.assertEqual(self.client_connection.inform.call_count, 1)
         (inf_msg,), kwargs = self.client_connection.inform.call_args
         self.assertSequenceEqual(inf_msg.arguments, arguments)
-        self.assertEqual(inf_msg.name, 'test-request')
-        self.assertEqual(inf_msg.mid, b'42')
+        self.assertEqual(inf_msg.name, "test-request")
+        self.assertEqual(inf_msg.mid, b"42")
         self.assertEqual(inf_msg.mtype, katcp.Message.INFORM)
 
     def test_reply(self):
-        arguments = (b'inf1', b'inf2')
+        arguments = (b"inf1", b"inf2")
         self.DUT.reply(*arguments)
         self.assertEqual(self.client_connection.reply.call_count, 1)
         (rep_msg, req_msg), kwargs = self.client_connection.reply.call_args
         self.assertIs(req_msg, self.req_msg)
         self.assertSequenceEqual(rep_msg.arguments, arguments)
-        self.assertEqual(rep_msg.name, 'test-request')
-        self.assertEqual(rep_msg.mid, b'42')
+        self.assertEqual(rep_msg.name, "test-request")
+        self.assertEqual(rep_msg.mid, b"42")
         self.assertEqual(rep_msg.mtype, katcp.Message.REPLY)
         # Test that we can't reply twice
         with self.assertRaises(RuntimeError):
             self.DUT.reply(*arguments)
 
     def test_reply_with_msg(self):
-        rep_msg = katcp.Message.reply('test-request', 'inf1', 'inf2')
+        rep_msg = katcp.Message.reply("test-request", "inf1", "inf2")
         self.DUT.reply_with_message(rep_msg.copy())
         self.assertEqual(self.client_connection.reply.call_count, 1)
         (actual_rep_msg, req_msg), kwargs = self.client_connection.reply.call_args
@@ -146,42 +155,40 @@ class test_ClientRequestConnection(unittest.TestCase):
             self.DUT.reply_with_message(rep_msg)
 
     def test_reply_message(self):
-        arguments = (b'inf1', b'inf2')
+        arguments = (b"inf1", b"inf2")
         rep_msg = self.DUT.make_reply(*arguments)
         self.assertSequenceEqual(rep_msg.arguments, arguments)
-        self.assertEqual(rep_msg.name, 'test-request')
-        self.assertEqual(rep_msg.mid, b'42')
+        self.assertEqual(rep_msg.name, "test-request")
+        self.assertEqual(rep_msg.mid, b"42")
         self.assertEqual(rep_msg.mtype, katcp.Message.REPLY)
 
-class TestDeviceServerV4(unittest.TestCase, TestUtilMixin):
 
+class TestDeviceServerV4(unittest.TestCase, TestUtilMixin):
     class DeviceTestServerV4(DeviceTestServer):
         ## Protocol versions and flags for a katcp v4 server
-        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, set([
-            katcp.ProtocolFlags.MULTI_CLIENT,
-            ]))
+        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, set([katcp.ProtocolFlags.MULTI_CLIENT]))
 
     def setUp(self):
-        self.server = self.DeviceTestServerV4('', 0)
+        self.server = self.DeviceTestServerV4("", 0)
 
     def test_log(self):
         self.server.mass_inform = mock.Mock()
-        self.server.log.warn('A warning', timestamp=1234)
+        self.server.log.warn("A warning", timestamp=1234)
         self.assertEqual(self.server.mass_inform.call_count, 1)
-        (msg, ), _ = self.server.mass_inform.call_args
+        (msg,), _ = self.server.mass_inform.call_args
         level, timestamp, name, log_message = msg.arguments
-        self.assertEqual(msg.name, 'log')
+        self.assertEqual(msg.name, "log")
         self.assertIs(msg.mid, None)
         # Timestamp should be in miliseconds
-        self.assertEqual(timestamp, b'1234000')
-        self.assertIn(b'A warning', log_message)
+        self.assertEqual(timestamp, b"1234000")
+        self.assertIn(b"A warning", log_message)
 
     def test_on_client_connect(self):
         fake_sock = mock.Mock()
         conn = katcp.server.ClientConnection(self.server._server, fake_sock)
         mock_conn = mock.Mock(spec=conn)
-        self.server.BUILD_INFO = ('buildy', 1, 2, 'g')
-        self.server.VERSION_INFO = ('deviceapi', 5, 6)
+        self.server.BUILD_INFO = ("buildy", 1, 2, "g")
+        self.server.VERSION_INFO = ("deviceapi", 5, 6)
         # Hack around ioloop thread asserts
         self.server._server.ioloop_thread_id = _thread.get_ident()
         # Test call
@@ -191,80 +198,88 @@ class TestDeviceServerV4(unittest.TestCase, TestUtilMixin):
         self.assertEqual(mock_conn.inform.call_count, no_msgs)
         # Get all the inform messages
         msgs = [str(call[0][0]) for call in mock_conn.inform.call_args_list]
-        self._assert_msgs_equal(msgs, (
-            r'#version deviceapi-5.6',
-            r'#build-state buildy-1.2g'))
+        self._assert_msgs_equal(
+            msgs, (r"#version deviceapi-5.6", r"#build-state buildy-1.2g")
+        )
 
     def test_sensor_sampling(self):
         start_thread_with_cleanup(self, self.server)
-        s = katcp.Sensor.boolean('a-sens')
+        s = katcp.Sensor.boolean("a-sens")
         s.set(1234, katcp.Sensor.NOMINAL, True)
         self.server.add_sensor(s)
         self.server._send_message = WaitingMock()
-        self.server.wait_running(timeout=1.)
+        self.server.wait_running(timeout=1.0)
         self.assertTrue(self.server.running())
         self.server._strategies = defaultdict(lambda: {})
-        req = mock_req('sensor-sampling', 'a-sens', 'event')
+        req = mock_req("sensor-sampling", "a-sens", "event")
         self.server.request_sensor_sampling(req, req.msg).result(timeout=1)
         inf = req.client_connection.inform
         inf.assert_wait_call_count(count=1)
-        (inf_msg, ) = inf.call_args[0]
-        self._assert_msgs_equal([inf_msg], (
-            r'#sensor-status 1234000 1 a-sens nominal 1',))
-        req = mock_req('sensor-sampling', 'a-sens', 'period', 1000)
+        (inf_msg,) = inf.call_args[0]
+        self._assert_msgs_equal(
+            [inf_msg], (r"#sensor-status 1234000 1 a-sens nominal 1",)
+        )
+        req = mock_req("sensor-sampling", "a-sens", "period", 1000)
         self.server.request_sensor_sampling(req, req.msg).result()
         client = req.client_connection
         strat = self.server._strategies[client][s]
         # Test that the periodic update period is converted to seconds
-        self.assertEqual(strat._period, 1.)
+        self.assertEqual(strat._period, 1.0)
         # test that parameters returned by the request matches v4 format.
         #
         # We need to pass in the same client_conn as used by the previous
         # request since strategies are bound to specific connections
-        req = mock_req('sensor-sampling', 'a-sens', client_conn=client)
+        req = mock_req("sensor-sampling", "a-sens", client_conn=client)
         reply = self.server.request_sensor_sampling(req, req.msg).result()
-        self._assert_msgs_equal([reply],
-                                ['!sensor-sampling ok a-sens period 1000'])
+        self._assert_msgs_equal([reply], ["!sensor-sampling ok a-sens period 1000"])
         # event-rate is not an allowed v4 strategy
         with self.assertRaises(FailReply):
-            self.server.request_sensor_sampling(req, katcp.Message.request(
-                'sensor-sampling', 'a-sens', 'event-rate', 1000, 2000)).result()
+            self.server.request_sensor_sampling(
+                req,
+                katcp.Message.request(
+                    "sensor-sampling", "a-sens", "event-rate", 1000, 2000
+                ),
+            ).result()
         # differential-rate is not an allowed v4 strategy
         with self.assertRaises(FailReply):
-            self.server.request_sensor_sampling(req, katcp.Message.request(
-             'sensor-sampling', 'a-sens', 'differential-rate', 1, 1000, 2000)).result()
+            self.server.request_sensor_sampling(
+                req,
+                katcp.Message.request(
+                    "sensor-sampling", "a-sens", "differential-rate", 1, 1000, 2000
+                ),
+            ).result()
 
     def test_sensor_value(self):
-        s = katcp.Sensor.boolean('a-sens')
+        s = katcp.Sensor.boolean("a-sens")
         s.set(1234, katcp.Sensor.NOMINAL, True)
         self.server.add_sensor(s)
         client_conn = ClientConnectionTest()
-        self.server.handle_message(client_conn, katcp.Message.request(
-            'sensor-value', 'a-sens'))
-        self._assert_msgs_equal(client_conn.messages, [
-            '#sensor-value 1234000 1 a-sens nominal 1',
-            '!sensor-value ok 1'])
+        self.server.handle_message(
+            client_conn, katcp.Message.request("sensor-value", "a-sens")
+        )
+        self._assert_msgs_equal(
+            client_conn.messages,
+            ["#sensor-value 1234000 1 a-sens nominal 1", "!sensor-value ok 1"],
+        )
 
     def test_excluded_default_handlers(self):
         """
         Test that default handers from higher KATCP versions are not included
 
         """
-        self.assertNotIn('request-timeout-hint', self.server._request_handlers)
-        self.assertNotIn('version-list', self.server._request_handlers)
+        self.assertNotIn("request-timeout-hint", self.server._request_handlers)
+        self.assertNotIn("version-list", self.server._request_handlers)
 
 
 class TestDeviceServerV4Async(TestDeviceServerV4):
-
     class DeviceTestServerV4(DeviceTestServer):
         ## Protocol versions and flags for a katcp v4 server
-        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, set([
-            katcp.ProtocolFlags.MULTI_CLIENT,
-            ]))
+        PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, set([katcp.ProtocolFlags.MULTI_CLIENT]))
 
         def __init__(self, *args, **kwargs):
             super(TestDeviceServerV4Async.DeviceTestServerV4, self).__init__(
-                *args, **kwargs)
+                *args, **kwargs
+            )
             self.set_concurrency_options(thread_safe=False, handler_thread=False)
 
 
@@ -272,37 +287,41 @@ class TestVersionCompatibility(unittest.TestCase):
     def test_wrong_version(self):
         class DeviceTestServerWrong(DeviceTestServer):
             ## Protocol versions and flags for a katcp v4 server
-            PROTOCOL_INFO = katcp.ProtocolFlags(3, 0, set([
-                katcp.ProtocolFlags.MULTI_CLIENT,
-                ]))
+            PROTOCOL_INFO = katcp.ProtocolFlags(
+                3, 0, set([katcp.ProtocolFlags.MULTI_CLIENT])
+            )
 
         # Only major versions 4 and 5 are supported
         with self.assertRaises(ValueError):
-            DeviceTestServerWrong('', 0)
+            DeviceTestServerWrong("", 0)
         DeviceTestServerWrong.PROTOCOL_INFO.major = 6
         with self.assertRaises(ValueError):
-            DeviceTestServerWrong('', 0)
+            DeviceTestServerWrong("", 0)
+
 
 katcp_version = __version__
+
 
 class test_DeviceServer(unittest.TestCase, TestUtilMixin):
 
     expected_connect_messages = (
-            # Will have to be updated if the default KATCP protocol
-            # spec version changes
-            r'#version-connect katcp-protocol 5.0-IM',
-            r'#version-connect katcp-library katcp-python-%s' % katcp_version,
-            r'#version-connect katcp-device deviceapi-5.6 buildy-1.2g')
+        # Will have to be updated if the default KATCP protocol
+        # spec version changes
+        r"#version-connect katcp-protocol 5.0-IM",
+        r"#version-connect katcp-library katcp-python-%s" % katcp_version,
+        r"#version-connect katcp-device deviceapi-5.6 buildy-1.2g",
+    )
 
     def setUp(self):
-        self.server = DeviceTestServer('', 0)
+        self.server = DeviceTestServer("", 0)
 
     def test_on_client_connect(self):
         fake_sock = mock.Mock()
         mock_conn = mock.Mock(
-            spec=katcp.server.ClientConnection(self.server._server, fake_sock))
-        self.server.BUILD_INFO = ('buildy', 1, 2, 'g')
-        self.server.VERSION_INFO = ('deviceapi', 5, 6)
+            spec=katcp.server.ClientConnection(self.server._server, fake_sock)
+        )
+        self.server.BUILD_INFO = ("buildy", 1, 2, "g")
+        self.server.VERSION_INFO = ("deviceapi", 5, 6)
         # Hack around ioloop thread asserts
         self.server._server.ioloop_thread_id = _thread.get_ident()
         # Test call
@@ -320,7 +339,8 @@ class test_DeviceServer(unittest.TestCase, TestUtilMixin):
         client_connection = ClientConnectionTest()
         self.server.ioloop.make_current()
         tf = self.server.handle_message(
-            client_connection, katcp.Message.request('sensor-sampling-clear'))
+            client_connection, katcp.Message.request("sensor-sampling-clear")
+        )
         # tf may be a tornado (not thread-safe) future, so we wrap it in a thread-safe
         # future object
         f = Future()
@@ -328,14 +348,13 @@ class test_DeviceServer(unittest.TestCase, TestUtilMixin):
         f.result(timeout=1)
         # Ensure that the tornado future has finished running its callbacks
         self.server.sync_with_ioloop()
-        self._assert_msgs_equal(client_connection.messages, [
-            '!sensor-sampling-clear ok'])
+        self._assert_msgs_equal(client_connection.messages, ["!sensor-sampling-clear ok"])
         self.server.clear_strategies.assert_called_once_with(client_connection)
 
     def test_has_sensor(self):
-        self.assertFalse(self.server.has_sensor('blaah'))
-        self.server.add_sensor(katcp.Sensor.boolean('blaah', 'blaah sens'))
-        self.assertTrue(self.server.has_sensor('blaah'))
+        self.assertFalse(self.server.has_sensor("blaah"))
+        self.server.add_sensor(katcp.Sensor.boolean("blaah", "blaah sens"))
+        self.assertTrue(self.server.has_sensor("blaah"))
 
     def test_excluded_default_handlers(self):
         """
@@ -344,20 +363,18 @@ class test_DeviceServer(unittest.TestCase, TestUtilMixin):
         """
         # TODO NM 2017-04-18 This should probably be removed if we do official
         # KATCP v5.1 release and make it the default server version
-        self.assertNotIn('request-timeout-hint', self.server._request_handlers)
+        self.assertNotIn("request-timeout-hint", self.server._request_handlers)
 
 
 class test_DeviceServerAsync(test_DeviceServer):
     def setUp(self):
         super(test_DeviceServerAsync, self).setUp()
-        self.server.set_concurrency_options(
-            thread_safe=False, handler_thread=False)
+        self.server.set_concurrency_options(thread_safe=False, handler_thread=False)
 
 
 class test_DeviceServerMemoryLeaks(unittest.TestCase):
-
     def test_no_memory_leak_after_usage(self):
-        server = DeviceTestServer('', 0)
+        server = DeviceTestServer("", 0)
         wr = weakref.ref(server)
 
         server.start()
@@ -375,71 +392,75 @@ class test_DeviceServer51(test_DeviceServer):
     """Proposed additional tests for Verion 5.1 server"""
 
     expected_connect_messages = (
-        r'#version-connect katcp-protocol 5.1-IMT',
-        r'#version-connect katcp-library katcp-python-%s' % katcp_version,
-        r'#version-connect katcp-device deviceapi-5.6 buildy-1.2g')
+        r"#version-connect katcp-protocol 5.1-IMT",
+        r"#version-connect katcp-library katcp-python-%s" % katcp_version,
+        r"#version-connect katcp-device deviceapi-5.6 buildy-1.2g",
+    )
 
     def setUp(self):
         class DeviceTestServer51(DeviceTestServer):
             PROTOCOL_INFO = katcp.ProtocolFlags(
-            5, 1, [
-                katcp.ProtocolFlags.MULTI_CLIENT,
-                katcp.ProtocolFlags.MESSAGE_IDS,
-                katcp.ProtocolFlags.REQUEST_TIMEOUT_HINTS])
-        self.server = DeviceTestServer51('', 0)
-        self.server.set_concurrency_options(
-            thread_safe=False, handler_thread=False)
+                5,
+                1,
+                [
+                    katcp.ProtocolFlags.MULTI_CLIENT,
+                    katcp.ProtocolFlags.MESSAGE_IDS,
+                    katcp.ProtocolFlags.REQUEST_TIMEOUT_HINTS,
+                ],
+            )
+
+        self.server = DeviceTestServer51("", 0)
+        self.server.set_concurrency_options(thread_safe=False, handler_thread=False)
 
     def test_excluded_default_handlers(self):
-        pass                  #  No excluded default handlers for v5.1 as of yet
+        pass  #  No excluded default handlers for v5.1 as of yet
 
     def test_request_timeout_hint(self):
-        req = mock_req('request-timeout-hint')
+        req = mock_req("request-timeout-hint")
         handle_mock_req(self.server, req)
         # Check that the default test server "slow command" request has the
         # expected timeout hint of 99 seconds
-        self._assert_msgs_equal([req.reply_msg],
-                                ['!request-timeout-hint ok 1'])
-        self._assert_msgs_equal(req.inform_msgs,
-                                ['#request-timeout-hint slow-command 99.0'])
+        self._assert_msgs_equal([req.reply_msg], ["!request-timeout-hint ok 1"])
+        self._assert_msgs_equal(
+            req.inform_msgs, ["#request-timeout-hint slow-command 99.0"]
+        )
         # Check that a request without a hint gives a timeout of 0 if explicitly
         # asked for
-        req = mock_req('request-timeout-hint', 'help')
+        req = mock_req("request-timeout-hint", "help")
         handle_mock_req(self.server, req)
-        self._assert_msgs_equal([req.reply_msg],
-                                ['!request-timeout-hint ok 1'])
-        self._assert_msgs_equal(req.inform_msgs,
-                                ['#request-timeout-hint help 0.0'])
+        self._assert_msgs_equal([req.reply_msg], ["!request-timeout-hint ok 1"])
+        self._assert_msgs_equal(req.inform_msgs, ["#request-timeout-hint help 0.0"])
 
         # Now set hint on help command and check that it is reflected. Note, in
         # Python 2 you cannot add a new attribute to an instance method. We need
         # to make a copy of the original handler function using partial and then
         # mess with that copy.
-        handler_original = self.server._request_handlers['help']
+        handler_original = self.server._request_handlers["help"]
         if PY2:
-            handler_updated = wraps(handler_original)(partial(handler_original,
-                                                              self.server))
+            handler_updated = wraps(handler_original)(
+                partial(handler_original, self.server)
+            )
         else:
             handler_updated = handler_original
-        self.server._request_handlers[
-            'help'] = kattypes.request_timeout_hint(25.5)(handler_updated)
-        req = mock_req('request-timeout-hint', 'help')
+        self.server._request_handlers["help"] = kattypes.request_timeout_hint(25.5)(
+            handler_updated
+        )
+        req = mock_req("request-timeout-hint", "help")
         handle_mock_req(self.server, req)
-        self._assert_msgs_equal([req.reply_msg],
-                                ['!request-timeout-hint ok 1'])
-        self._assert_msgs_equal(req.inform_msgs,
-                                ['#request-timeout-hint help 25.5'])
-        req = mock_req('request-timeout-hint')
+        self._assert_msgs_equal([req.reply_msg], ["!request-timeout-hint ok 1"])
+        self._assert_msgs_equal(req.inform_msgs, ["#request-timeout-hint help 25.5"])
+        req = mock_req("request-timeout-hint")
         handle_mock_req(self.server, req)
         # Check that the default test server "slow command" request has the
         # expected timeout hint of 99 seconds
-        self._assert_msgs_equal([req.reply_msg],
-                                ['!request-timeout-hint ok 2'])
-        self._assert_msgs_equal(req.inform_msgs,
-                                ['#request-timeout-hint help 25.5',
-                                 '#request-timeout-hint slow-command 99.0'])
-
-
+        self._assert_msgs_equal([req.reply_msg], ["!request-timeout-hint ok 2"])
+        self._assert_msgs_equal(
+            req.inform_msgs,
+            [
+                "#request-timeout-hint help 25.5",
+                "#request-timeout-hint slow-command 99.0",
+            ],
+        )
 
 
 class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
@@ -456,31 +477,26 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         start_thread_with_cleanup(self, self.client, start_timeout=1)
         self.assertTrue(self.client.wait_protocol(timeout=1))
 
-
     def _setup_server(self):
-        self.server = DeviceTestServer('', 0)
+        self.server = DeviceTestServer("", 0)
         start_thread_with_cleanup(self, self.server, start_timeout=1)
 
     def test_log(self):
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST,
-                replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
 
         def tst():
-            with mock.patch('katcp.server.time.time') as m_time:
+            with mock.patch("katcp.server.time.time") as m_time:
                 m_time.return_value = 1234
-                self.server.log.error('An error')
+                self.server.log.error("An error")
+
         self.server.ioloop.add_callback(tst)
 
         get_msgs.wait_number(1)
-        self._assert_msgs_equal(
-            get_msgs(), [r"#log error 1234.000000 root An\_error"])
+        self._assert_msgs_equal(get_msgs(), [r"#log error 1234.000000 root An\_error"])
 
     def test_simple_connect(self):
         """Test a simple server setup and teardown with client connect."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST,
-                replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
         # basic send
         self.client.request(katcp.Message.request("foo"), use_mid=False)
 
@@ -491,34 +507,37 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self.client.raw_send(b"m arg1 arg2")
         self.client.raw_send(b"\n")
 
-        self._assert_msgs_equal(get_msgs(min_number=4), [
-            r"!foo invalid Unknown\_request.",
-            r"!bar-boom invalid Unknown\_request.",
-            r"!baz invalid Unknown\_request.",
-            r"!boom invalid Unknown\_request.",
-        ])
+        self._assert_msgs_equal(
+            get_msgs(min_number=4),
+            [
+                r"!foo invalid Unknown\_request.",
+                r"!bar-boom invalid Unknown\_request.",
+                r"!baz invalid Unknown\_request.",
+                r"!boom invalid Unknown\_request.",
+            ],
+        )
 
     def test_get_sensor(self):
-        self.client.get_sensor('an.int', int)
-        response = self.client.get_sensor('an.int')
-        self.assertEquals(response[0], '3')
-        self.client.get_sensor_value('an.int', int)
-        self.client.assert_sensor_equals('an.int', 3, int, status='nominal')
-        self.client.assert_sensor_status_equals('an.int', 'nominal')
+        self.client.get_sensor("an.int", int)
+        response = self.client.get_sensor("an.int")
+        self.assertEquals(response[0], "3")
+        self.client.get_sensor_value("an.int", int)
+        self.client.assert_sensor_equals("an.int", 3, int, status="nominal")
+        self.client.assert_sensor_status_equals("an.int", "nominal")
 
     def test_bad_requests(self):
         """Test request failure paths in device server."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST, replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
         self.client.raw_send(b"bad msg\n")
         # wait for reply
-        self.client.blocking_request(
-            katcp.Message.request("watchdog"), use_mid=False)
-        self._assert_msgs_like(get_msgs(), [
-            (r"#log error", r"KatcpSyntaxError:"
-                            r"\_Bad\_type\_character\_'b'.\n"),
-            (r"!watchdog ok", ""),
-        ])
+        self.client.blocking_request(katcp.Message.request("watchdog"), use_mid=False)
+        self._assert_msgs_like(
+            get_msgs(),
+            [
+                (r"#log error", r"KatcpSyntaxError:" r"\_Bad\_type\_character\_'b'.\n"),
+                (r"!watchdog ok", ""),
+            ],
+        )
 
     def test_slow_client(self):
         # Test that server does not choke sending messages to slow clients
@@ -534,20 +553,18 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         # Send a bunch of request to the server, but don't read anything from
         # the server
         try:
-            slow_sock.sendall(b'?help\n'*1000000)
+            slow_sock.sendall(b"?help\n" * 1000000)
         except (socket.error, socket.timeout):
             pass
 
         t0 = time.time()
         # Request should not have taken a very long time.
-        self.client.assert_request_succeeds('help', informs_count=NUM_HELP_MESSAGES)
+        self.client.assert_request_succeeds("help", informs_count=NUM_HELP_MESSAGES)
         self.assertTrue(time.time() - t0 < 1.5)
-
 
     def test_server_ignores_informs_and_replies(self):
         """Test server ignores informs and replies."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST, replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
         self.client.raw_send(b"#some inform\n")
         self.client.raw_send(b"!some reply\n")
 
@@ -557,8 +574,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
 
     def test_standard_requests(self):
         """Test standard request and replies."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST, replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
         nomid_req = partial(self.client.blocking_request, use_mid=False)
         nomid_req(katcp.Message.request("watchdog"))
         nomid_req(katcp.Message.request("restart"))
@@ -575,16 +591,14 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         nomid_req(katcp.Message.request("sensor-list", "an.unknown"))
         nomid_req(katcp.Message.request("sensor-value"))
         nomid_req(katcp.Message.request("sensor-value", "an.int"))
-        nomid_req(katcp.Message.request("sensor-value",
-                                                  "an.unknown"))
+        nomid_req(katcp.Message.request("sensor-value", "an.unknown"))
         nomid_req(katcp.Message.request("sensor-sampling", "an.int"))
-        nomid_req(katcp.Message.request("sensor-sampling", "an.int",
-                                                  "differential", "2"))
-        nomid_req(katcp.Message.request("sensor-sampling", "an.int",
-                                                  "event-rate", "2", "3"))
+        nomid_req(katcp.Message.request("sensor-sampling", "an.int", "differential", "2"))
+        nomid_req(
+            katcp.Message.request("sensor-sampling", "an.int", "event-rate", "2", "3")
+        )
         nomid_req(katcp.Message.request("sensor-sampling"))
-        nomid_req(katcp.Message.request("sensor-sampling",
-                                                  "an.unknown", "auto"))
+        nomid_req(katcp.Message.request("sensor-sampling", "an.unknown", "auto"))
         nomid_req(katcp.Message.request("sensor-sampling", "an.int", "unknown"))
 
         def tst():
@@ -594,6 +608,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             self.server.log.warn("warn-msg")
             self.server.log.error("error-msg")
             self.server.log.fatal("fatal-msg")
+
         self.server.ioloop.add_callback(tst)
         self.assertEqual(self.server.restart_queue.get_nowait(), self.server)
         expected_msgs = [
@@ -673,8 +688,7 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
 
     def test_standard_requests_with_ids(self):
         """Test standard request and replies with message ids."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST, replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
 
         current_id = [0]
 
@@ -684,7 +698,6 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
 
         def mid_req(*args):
             return katcp.Message.request(*args, mid=mid())
-
 
         self.client.request(mid_req("watchdog"))
         self.client._next_id = mid  # mock our mid generator for testing
@@ -704,15 +717,15 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self.client.request(mid_req("sensor-value", "an.int"))
         self.client.request(mid_req("sensor-value", "an.unknown"))
         self.client.blocking_request(mid_req("sensor-sampling", "an.int"))
-        self.client.blocking_request(mid_req(
-            "sensor-sampling", "an.int", "differential", "2"))
-        self.client.blocking_request(mid_req(
-            "sensor-sampling", "an.int", "event-rate", "2", "3")),
+        self.client.blocking_request(
+            mid_req("sensor-sampling", "an.int", "differential", "2")
+        )
+        self.client.blocking_request(
+            mid_req("sensor-sampling", "an.int", "event-rate", "2", "3")
+        ),
         self.client.blocking_request(mid_req("sensor-sampling"))
-        self.client.blocking_request(mid_req(
-            "sensor-sampling", "an.unknown", "auto"))
-        self.client.blocking_request(mid_req(
-            "sensor-sampling", "an.int", "unknown"))
+        self.client.blocking_request(mid_req("sensor-sampling", "an.unknown", "auto"))
+        self.client.blocking_request(mid_req("sensor-sampling", "an.int", "unknown"))
 
         def tst():
             self.server.log.trace("trace-msg")
@@ -801,84 +814,98 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self._assert_msgs_like(get_msgs(min_number=len(expected_msgs)), expected_msgs)
 
     def test_sensor_list_regex(self):
-        reply, informs = self.client.blocking_request(katcp.Message.request(
-                "sensor-list", "/a.*/"), use_mid=False)
-        self._assert_msgs_equal(informs + [reply], [
-            r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
-            r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
-            r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
-            r"#sensor-list an.int An\_Integer. count integer -5 5",
-            r"!sensor-list ok 4",
-        ])
+        reply, informs = self.client.blocking_request(
+            katcp.Message.request("sensor-list", "/a.*/"), use_mid=False
+        )
+        self._assert_msgs_equal(
+            informs + [reply],
+            [
+                r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
+                r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
+                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                r"#sensor-list an.int An\_Integer. count integer -5 5",
+                r"!sensor-list ok 4",
+            ],
+        )
 
-        reply, informs = self.client.blocking_request(katcp.Message.request(
-                "sensor-list", "//"), use_mid=False)
-        self._assert_msgs_equal(informs + [reply], [
-            r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
-            r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
-            r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
-            r"#sensor-list an.int An\_Integer. count integer -5 5",
-            r"!sensor-list ok 4",
-        ])
+        reply, informs = self.client.blocking_request(
+            katcp.Message.request("sensor-list", "//"), use_mid=False
+        )
+        self._assert_msgs_equal(
+            informs + [reply],
+            [
+                r"#sensor-list a.discrete A\_Discrete. \@ discrete one two three",
+                r"#sensor-list a.float A\_Float. \@ float -123.4 123.4",
+                r"#sensor-list a.floatwithzero A\_Float\_with\_zero. \@ float -123.0 123.0",
+                r"#sensor-list an.int An\_Integer. count integer -5 5",
+                r"!sensor-list ok 4",
+            ],
+        )
 
-        reply, informs = self.client.blocking_request(katcp.Message.request(
-                "sensor-list", "/^int/"), use_mid=False)
-        self._assert_msgs_equal(informs + [reply], [
-            r"!sensor-list ok 0",
-        ])
+        reply, informs = self.client.blocking_request(
+            katcp.Message.request("sensor-list", "/^int/"), use_mid=False
+        )
+        self._assert_msgs_equal(informs + [reply], [r"!sensor-list ok 0"])
 
     def test_sensor_value_regex(self):
-        reply, informs = self.client.blocking_request(katcp.Message.request(
-                "sensor-value", "/a.*/"), use_mid=False)
-        self._assert_msgs_equal(informs + [reply], [
-            r'#sensor-value 12345.000000 1 a.discrete nominal one',
-            r"#sensor-value 12345.000000 1 a.float nominal 12.0",
-            r"#sensor-value 12345.000000 1 a.floatwithzero nominal 12.0",
-            r"#sensor-value 12345.000000 1 an.int nominal 3",
-            r"!sensor-value ok 4",
-        ])
+        reply, informs = self.client.blocking_request(
+            katcp.Message.request("sensor-value", "/a.*/"), use_mid=False
+        )
+        self._assert_msgs_equal(
+            informs + [reply],
+            [
+                r"#sensor-value 12345.000000 1 a.discrete nominal one",
+                r"#sensor-value 12345.000000 1 a.float nominal 12.0",
+                r"#sensor-value 12345.000000 1 a.floatwithzero nominal 12.0",
+                r"#sensor-value 12345.000000 1 an.int nominal 3",
+                r"!sensor-value ok 4",
+            ],
+        )
 
-        reply, informs = self.client.blocking_request(katcp.Message.request(
-                "sensor-value", "//"), use_mid=False)
-        self._assert_msgs_equal(informs + [reply], [
-            r'#sensor-value 12345.000000 1 a.discrete nominal one',
-            r'#sensor-value 12345.000000 1 a.float nominal 12.0',
-            r'#sensor-value 12345.000000 1 a.floatwithzero nominal 12.0',
-            r"#sensor-value 12345.000000 1 an.int nominal 3",
-            r"!sensor-value ok 4",
-        ])
+        reply, informs = self.client.blocking_request(
+            katcp.Message.request("sensor-value", "//"), use_mid=False
+        )
+        self._assert_msgs_equal(
+            informs + [reply],
+            [
+                r"#sensor-value 12345.000000 1 a.discrete nominal one",
+                r"#sensor-value 12345.000000 1 a.float nominal 12.0",
+                r"#sensor-value 12345.000000 1 a.floatwithzero nominal 12.0",
+                r"#sensor-value 12345.000000 1 an.int nominal 3",
+                r"!sensor-value ok 4",
+            ],
+        )
 
-        reply, informs = self.client.blocking_request(katcp.Message.request(
-                "sensor-value", "/^int/"), use_mid=False)
-        self._assert_msgs_equal(informs + [reply], [
-            r"!sensor-value ok 0",
-        ])
+        reply, informs = self.client.blocking_request(
+            katcp.Message.request("sensor-value", "/^int/"), use_mid=False
+        )
+        self._assert_msgs_equal(informs + [reply], [r"!sensor-value ok 0"])
 
     def test_client_list(self):
         reply, informs = self.client.blocking_request(
-            katcp.Message.request('client-list'), use_mid=False)
-        self.assertEqual(str(reply), '!client-list ok 1')
+            katcp.Message.request("client-list"), use_mid=False
+        )
+        self.assertEqual(str(reply), "!client-list ok 1")
         self.assertEqual(len(informs), 1)
         inform = str(informs[0])
-        self.assertTrue(inform.startswith('#client-list 127.0.0.1:'))
+        self.assertTrue(inform.startswith("#client-list 127.0.0.1:"))
         _, addr = inform.split()
-        host, port = addr.split(':')
+        host, port = addr.split(":")
         port = int(port)
         self.assertEqual((host, port), self.client.sockname)
 
     def test_halt_request(self):
         """Test halt request."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST, replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
         self.client.request(katcp.Message.request("halt"))
         # hack to hide re-connect exception
         self.client.connect = lambda: None
         self.server.join()
 
-        self._assert_msgs_equal(get_msgs(min_number=2), [
-            r"!halt[1] ok",
-            r"#disconnect Device\_server\_shutting\_down.",
-        ])
+        self._assert_msgs_equal(
+            get_msgs(min_number=2),
+            [r"!halt[1] ok", r"#disconnect Device\_server\_shutting\_down."],
+        )
 
     def test_bad_handlers(self):
         """Test that bad request and inform handlers are picked up."""
@@ -908,13 +935,12 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             request_bar = 1
             inform_baz = 2
 
-        assert("bar" not in SortOfOkayServer._request_handlers)
-        assert("baz" not in SortOfOkayServer._inform_handlers)
+        assert "bar" not in SortOfOkayServer._request_handlers
+        assert "baz" not in SortOfOkayServer._inform_handlers
 
     def test_handler_exceptions(self):
         """Test handling of failure replies and other exceptions."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST, replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
         self.assertTrue(self.client.wait_protocol(timeout=1))
 
         self.client.request(katcp.Message.request("raise-exception"))
@@ -922,11 +948,13 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
 
         time.sleep(0.1)
 
-        self._assert_msgs_like(get_msgs(), [
-            (r"!raise-exception[1] fail Traceback", ""),
-            (r"!raise-fail[2] fail There\_was\_a\_problem\_with\_your\_request.",
-             ""),
-        ])
+        self._assert_msgs_like(
+            get_msgs(),
+            [
+                (r"!raise-exception[1] fail Traceback", ""),
+                (r"!raise-fail[2] fail There\_was\_a\_problem\_with\_your\_request.", ""),
+            ],
+        )
 
     def test_decorated_handler(self):
         """Test handling with @request and @return_reply."""
@@ -936,32 +964,35 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         _int = 78
 
         do_raise = False
-        ok_msg = katcp.Message.request(
-            "decorated", _string, _float, _int, do_raise)
+        ok_msg = katcp.Message.request("decorated", _string, _float, _int, do_raise)
         reply, informs = self.client.blocking_request(ok_msg, use_mid=False)
-        self._assert_msgs_equal(informs + [reply], [
-            str(katcp.Message.inform("decorated", "_string", type(_string))),
-            str(katcp.Message.inform("decorated", "_float", type(_float))),
-            str(katcp.Message.inform("decorated", "_int", type(_int))),
-            str(katcp.Message.inform("decorated", "do_raise", type(do_raise))),
-            r"!decorated ok sss 1.5 78 0",
-        ])
+        self._assert_msgs_equal(
+            informs + [reply],
+            [
+                str(katcp.Message.inform("decorated", "_string", type(_string))),
+                str(katcp.Message.inform("decorated", "_float", type(_float))),
+                str(katcp.Message.inform("decorated", "_int", type(_int))),
+                str(katcp.Message.inform("decorated", "do_raise", type(do_raise))),
+                r"!decorated ok sss 1.5 78 0",
+            ],
+        )
 
         do_raise = True
-        fail_msg = katcp.Message.request(
-            "decorated", _string, _float, _int, do_raise)
+        fail_msg = katcp.Message.request("decorated", _string, _float, _int, do_raise)
         reply, informs = self.client.blocking_request(fail_msg, use_mid=False)
-        self._assert_msgs_like(informs + [reply], [
-            (r"!decorated fail Traceback", r"An\_exception\_occurred!\n")
-        ])
+        self._assert_msgs_like(
+            informs + [reply],
+            [(r"!decorated fail Traceback", r"An\_exception\_occurred!\n")],
+        )
 
     def test_decorated_return_exception_handler(self):
         """Test handling with @return_reply exception object."""
         msg = katcp.Message.request("decorated-return-exception")
         reply, informs = self.client.blocking_request(msg, use_mid=False)
-        self._assert_msgs_like(informs + [reply], [
-            (r"!decorated-return-exception fail An\_exception\_occurred!", "")
-        ])
+        self._assert_msgs_like(
+            informs + [reply],
+            [(r"!decorated-return-exception fail An\_exception\_occurred!", "")],
+        )
 
     def test_stop_and_restart(self):
         """Test stopping and restarting the device server."""
@@ -989,44 +1020,49 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         self.server.sync_with_ioloop()
 
         # check that client stream was removed from the KATCPServer
-        self.assertTrue(stream not in self.server._server._connections,
-                        "Expected %r to not be in %r" %
-                        (stream, self.server._server._connections))
+        self.assertTrue(
+            stream not in self.server._server._connections,
+            "Expected %r to not be in %r" % (stream, self.server._server._connections),
+        )
         # And check that the ClientConnection object was removed from the DeviceServer
-        self.assertTrue(client_conn not in self.server._client_conns,
-                        "Expected %r to not be in %r" %
-                        (client_conn, self.server._client_conns))
+        self.assertTrue(
+            client_conn not in self.server._client_conns,
+            "Expected %r to not be in %r" % (client_conn, self.server._client_conns),
+        )
 
     def test_sampling(self):
         """Test sensor sampling."""
-        get_msgs = self.client.message_recorder(
-                blacklist=self.BLACKLIST, replies=True)
+        get_msgs = self.client.message_recorder(blacklist=self.BLACKLIST, replies=True)
         self.client.wait_protocol(timeout=1)
-        self.client.request(katcp.Message.request(
-            "sensor-sampling", "an.int", "period", 1/32.))
+        self.client.request(
+            katcp.Message.request("sensor-sampling", "an.int", "period", 1 / 32.0)
+        )
 
         # Wait for the request reply and for the sensor update messages to
         # arrive. We expect update one the moment the sensor-sampling request is
         # made, then four more over 4/32. of a second, resutling in 6
         # messages. Wait 0.75 of a period longer just to be sure we get everything.
 
-        self.assertTrue(get_msgs.wait_number(6, timeout=4.75/32.))
+        self.assertTrue(get_msgs.wait_number(6, timeout=4.75 / 32.0))
         self.client.assert_request_succeeds("sensor-sampling", "an.int", "none")
         # Wait for reply to above request
         get_msgs.wait_number(7)
         msgs = get_msgs()
         updates = [x for x in msgs if x.name == "sensor-status"]
         others = [x for x in msgs if x.name != "sensor-status"]
-        self.assertTrue(abs(len(updates) - 5) < 2,
-                        "Expected 5 informs, saw %d." % len(updates))
+        self.assertTrue(
+            abs(len(updates) - 5) < 2, "Expected 5 informs, saw %d." % len(updates)
+        )
 
-        self._assert_msgs_equal(others, [
-            r"!sensor-sampling[1] ok an.int period %s" % (1/32.),
-            r"!sensor-sampling[2] ok an.int none",
-        ])
+        self._assert_msgs_equal(
+            others,
+            [
+                r"!sensor-sampling[1] ok an.int period %s" % (1 / 32.0),
+                r"!sensor-sampling[2] ok an.int none",
+            ],
+        )
 
-        self.assertEqual(updates[0].arguments[1:],
-                         [b"1", b"an.int", b"nominal", b"3"])
+        self.assertEqual(updates[0].arguments[1:], [b"1", b"an.int", b"nominal", b"3"])
 
         ## Now clear the strategies on this sensor
         # There should only be on connection to the server, so it should be
@@ -1034,12 +1070,12 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         client_conn = list(self.server._client_conns)[0]
         self.server.ioloop.add_callback(self.server.clear_strategies, client_conn)
         self.server.sync_with_ioloop()
-        self.client.assert_request_succeeds("sensor-sampling", "an.int",
-                                            args_equal=["an.int", "none"])
+        self.client.assert_request_succeeds(
+            "sensor-sampling", "an.int", args_equal=["an.int", "none"]
+        )
         # Check that we did not accidentally clobber the strategy datastructure
         # in the proccess
-        self.client.assert_request_succeeds(
-            "sensor-sampling", "an.int", "period", 0.125)
+        self.client.assert_request_succeeds("sensor-sampling", "an.int", "period", 0.125)
 
     def test_assert_request_fails(self):
         self.client.assert_request_fails("sensor-sampling", "an.nonexistentsensor")
@@ -1057,8 +1093,9 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             )
         with self.assertRaises(Exception):
             self.client.assert_request_fails(
-                "sensor-sampling", "an.int",
-                error_equals="Unknown sensor name: an.nonexistentsensor."
+                "sensor-sampling",
+                "an.int",
+                error_equals="Unknown sensor name: an.nonexistentsensor.",
             )
 
     def test_test_sensor_list(self):
@@ -1099,26 +1136,34 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
     def test_assert_request_succeeds(self):
         """Test exercises assert_request_succeeds"""
 
-        self.client.assert_request_succeeds("sensor-sampling", "an.int",
-                                            args_equal=["an.int", "none"])
-        self.client.assert_request_succeeds("sensor-sampling", b"an.int",
-                                            args_equal=["an.int", "none"])
-        self.client.assert_request_succeeds("sensor-sampling", b"an.int",
-                                            args_equal=[b"an.int", b"none"])
-        self.client.assert_request_succeeds("log-level", "debug", args_echo=True)
-        levels = ['off', b'fatal', 'error', b'warn', 'info', 'debug', 'trace', 'all']
-        self.client.assert_request_succeeds("log-level", args_in=[[level]
-                                                                  for level in levels])
         self.client.assert_request_succeeds(
-            "sensor-value", "an.int",
+            "sensor-sampling", "an.int", args_equal=["an.int", "none"]
+        )
+        self.client.assert_request_succeeds(
+            "sensor-sampling", b"an.int", args_equal=["an.int", "none"]
+        )
+        self.client.assert_request_succeeds(
+            "sensor-sampling", b"an.int", args_equal=[b"an.int", b"none"]
+        )
+        self.client.assert_request_succeeds("log-level", "debug", args_echo=True)
+        levels = ["off", b"fatal", "error", b"warn", "info", "debug", "trace", "all"]
+        self.client.assert_request_succeeds(
+            "log-level", args_in=[[level] for level in levels]
+        )
+        self.client.assert_request_succeeds(
+            "sensor-value",
+            "an.int",
             args_equal=["1"],
-            informs_args_equal=[['12345.000000', '1', 'an.int', 'nominal', '3']])
+            informs_args_equal=[["12345.000000", "1", "an.int", "nominal", "3"]],
+        )
 
         with self.assertRaises(Exception):
             self.client.assert_request_succeeds(
-                "sensor-value", "an.int",
+                "sensor-value",
+                "an.int",
                 args_equal=["1"],
-                informs_args_equal=[['12345.000000', '1', 'an.int', 'nominal', '3a']])
+                informs_args_equal=[["12345.000000", "1", "an.int", "nominal", "3a"]],
+            )
 
     def test_add_remove_sensors(self):
         """Test adding and removing sensors from a running device."""
@@ -1139,36 +1184,41 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
             try:
                 slow_wait_time = 20
                 # Kick off a slow, async request
-                slow_f = self.client.future_request(katcp.Message.request(
-                    'slow-command', slow_wait_time))
+                slow_f = self.client.future_request(
+                    katcp.Message.request("slow-command", slow_wait_time)
+                )
                 t0 = time.time()
                 # Do another normal request that should reply before the slow
                 # request
                 reply, _ = yield self.client.future_request(
-                    katcp.Message.request('watchdog'))
-                self.assertTrue(reply.reply_ok(), 'Normal request should succeed')
+                    katcp.Message.request("watchdog")
+                )
+                self.assertTrue(reply.reply_ok(), "Normal request should succeed")
                 # Normal request should reply quickly
                 t1 = time.time()
                 self.assertTrue(
-                    t1 - t0 < 0.1*slow_wait_time,
-                    'The normal request should reply almost immediately')
+                    t1 - t0 < 0.1 * slow_wait_time,
+                    "The normal request should reply almost immediately",
+                )
                 # Slow request should still be outstanding
                 self.assertFalse(
-                    slow_f.done(),
-                    'slow async request should not be complete yet')
+                    slow_f.done(), "slow async request should not be complete yet"
+                )
                 # Now cancel the slow command
                 reply, _ = yield self.client.future_request(
-                    katcp.Message.request('cancel-slow-command'))
-                self.assertTrue(reply.reply_ok(),
-                                '?cancel-slow-command should succeed')
+                    katcp.Message.request("cancel-slow-command")
+                )
+                self.assertTrue(reply.reply_ok(), "?cancel-slow-command should succeed")
                 slow_reply, _ = yield slow_f
                 self.assertTrue(
                     slow_reply.reply_ok(),
-                    '?slow-command should succeed after being cancelled')
+                    "?slow-command should succeed after being cancelled",
+                )
                 t2 = time.time()
                 self.assertTrue(
-                    t2 - t1 < 0.1*slow_wait_time,
-                    'Slow request should be cancelled almost immediately')
+                    t2 - t1 < 0.1 * slow_wait_time,
+                    "Slow request should be cancelled almost immediately",
+                )
             except Exception as exc:
                 tornado_future.set_exc_info(sys.exc_info())
                 threadsafe_future.set_exception(exc)
@@ -1178,7 +1228,8 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         tornado_future = gen.Future()
         threadsafe_future = Future()
         self.client.ioloop.add_callback(
-            do_async_request_test, threadsafe_future, tornado_future)
+            do_async_request_test, threadsafe_future, tornado_future
+        )
         try:
             threadsafe_future.result()
         except Exception:
@@ -1219,13 +1270,18 @@ class TestDeviceServerClientIntegrated(unittest.TestCase, TestUtilMixin):
         if PY2:
             self.client.test_help(request_names)
 
+
 class TestHandlerFiltering(unittest.TestCase):
     class DeviceWithEverything(katcp.DeviceServer):
         PROTOCOL_INFO = katcp.ProtocolFlags(
-            5, 1, [
+            5,
+            1,
+            [
                 katcp.ProtocolFlags.MULTI_CLIENT,
                 katcp.ProtocolFlags.MESSAGE_IDS,
-                katcp.ProtocolFlags.REQUEST_TIMEOUT_HINTS])
+                katcp.ProtocolFlags.REQUEST_TIMEOUT_HINTS,
+            ],
+        )
 
         def request_simple(self, req, msg):
             """A simple request"""
@@ -1241,27 +1297,25 @@ class TestHandlerFiltering(unittest.TestCase):
 
         @kattypes.request()
         @kattypes.has_katcp_protocol_flags(
-                [katcp.ProtocolFlags.MULTI_CLIENT,
-                 katcp.ProtocolFlags.MESSAGE_IDS])
+            [katcp.ProtocolFlags.MULTI_CLIENT, katcp.ProtocolFlags.MESSAGE_IDS]
+        )
         def request_flags(self, req):
             """Request some flags"""
 
-        @kattypes.has_katcp_protocol_flags(
-                [katcp.ProtocolFlags.MULTI_CLIENT])
+        @kattypes.has_katcp_protocol_flags([katcp.ProtocolFlags.MULTI_CLIENT])
         def request_fewer_flags(self, req, msg):
             """Request with fewer flags"""
 
         @kattypes.request()
         @kattypes.return_reply()
         @kattypes.minimum_katcp_version(5, 1)
-        @kattypes.has_katcp_protocol_flags(
-            [katcp.ProtocolFlags.MULTI_CLIENT])
+        @kattypes.has_katcp_protocol_flags([katcp.ProtocolFlags.MULTI_CLIENT])
         def request_version_and_flags(self, req, msg):
             """Request with version and flag requirements"""
 
-    all_expected_handlers = frozenset(['simple', 'version-51', 'version-5',
-                                       'flags', 'fewer-flags',
-                                       'version-and-flags'])
+    all_expected_handlers = frozenset(
+        ["simple", "version-51", "version-5", "flags", "fewer-flags", "version-and-flags"]
+    )
 
     def _test_handler_protocol_filters(self, DeviceCls, expected_handlers):
         """Test that handlers are filtered according to protocol requirements."""
@@ -1269,14 +1323,14 @@ class TestHandlerFiltering(unittest.TestCase):
         not_expected_handlers = self.all_expected_handlers - expected_handlers
         actual_device_handlers = set(DeviceCls._request_handlers.keys())
 
-        self.assertEqual(actual_device_handlers & expected_handlers,
-                         expected_handlers)
+        self.assertEqual(actual_device_handlers & expected_handlers, expected_handlers)
         self.assertEqual(set(), actual_device_handlers & not_expected_handlers)
 
     def test_handler_protocol_filters_all(self):
         """Test handler filtering where everything should be included"""
-        self._test_handler_protocol_filters(self.DeviceWithEverything,
-                                            self.all_expected_handlers)
+        self._test_handler_protocol_filters(
+            self.DeviceWithEverything, self.all_expected_handlers
+        )
 
     def test_handler_protocol_filters_five_one_with_nothing(self):
         """Test handler filtering where protocol flags exclude some"""
@@ -1285,49 +1339,44 @@ class TestHandlerFiltering(unittest.TestCase):
             PROTOCOL_INFO = katcp.ProtocolFlags(5, 1, [])
 
         self._test_handler_protocol_filters(
-            DeviceVersionFiveOneWithNothing,
-            ['simple', 'version-5', 'version-51'])
+            DeviceVersionFiveOneWithNothing, ["simple", "version-5", "version-51"]
+        )
 
     def test_handler_protocol_filters_five_one_with_multi(self):
         """Test handler filtering where protocol flags and version exclude some"""
 
         class DeviceVersionFiveOneWithMultiClient(self.DeviceWithEverything):
-            PROTOCOL_INFO = katcp.ProtocolFlags(5, 1, [
-                katcp.ProtocolFlags.MULTI_CLIENT])
+            PROTOCOL_INFO = katcp.ProtocolFlags(5, 1, [katcp.ProtocolFlags.MULTI_CLIENT])
 
         self._test_handler_protocol_filters(
             DeviceVersionFiveOneWithMultiClient,
-            ['simple', 'version-5', 'version-51', 'fewer-flags',
-            'version-and-flags'])
+            ["simple", "version-5", "version-51", "fewer-flags", "version-and-flags"],
+        )
 
     def test_handler_protocol_filters_five(self):
         """Test handler filtering for a KATCP v5.0 device"""
 
         class DeviceVersionFive(self.DeviceWithEverything):
             PROTOCOL_INFO = katcp.ProtocolFlags(
-                5, 0, [
-                    katcp.ProtocolFlags.MULTI_CLIENT,
-                    katcp.ProtocolFlags.MESSAGE_IDS])
+                5, 0, [katcp.ProtocolFlags.MULTI_CLIENT, katcp.ProtocolFlags.MESSAGE_IDS]
+            )
 
         self._test_handler_protocol_filters(
-            DeviceVersionFive,
-            ['simple', 'version-5', 'flags', 'fewer-flags'])
+            DeviceVersionFive, ["simple", "version-5", "flags", "fewer-flags"]
+        )
 
     def test_handler_protocol_filters_four(self):
         """Test handler filtering for a KATCP v4.0 device"""
 
         class DeviceVersionFour(self.DeviceWithEverything):
-            PROTOCOL_INFO = katcp.ProtocolFlags(
-                4, 0, [katcp.ProtocolFlags.MULTI_CLIENT])
+            PROTOCOL_INFO = katcp.ProtocolFlags(4, 0, [katcp.ProtocolFlags.MULTI_CLIENT])
 
-        self._test_handler_protocol_filters(
-            DeviceVersionFour, ['simple', 'fewer-flags'])
+        self._test_handler_protocol_filters(DeviceVersionFour, ["simple", "fewer-flags"])
 
 
 class TestDeviceServerClientIntegratedAsync(
-        tornado.testing.AsyncTestCase,
-        TestDeviceServerClientIntegrated):
-
+    tornado.testing.AsyncTestCase, TestDeviceServerClientIntegrated
+):
     def _setup_server(self):
-        self.server = AsyncDeviceTestServer('', 0)
+        self.server = AsyncDeviceTestServer("", 0)
         start_thread_with_cleanup(self, self.server, start_timeout=1)


### PR DESCRIPTION
this PR aligns `test_server.py` with black formatting  see https://github.com/ska-sa/katcp-python/pull/245#discussion_r479337508

please note that PR illustrates the use of black autoformat and the conflicts our internal CI and its linter. Please provide comments and suggestions directed to fixing this through configuring black and not issues that are presented in the CI through its linting. 