### PR TITLE
Update instructions on readthedocs for releasing a new version

### DIFF
--- a/doc/how_to_contribute.rst
+++ b/doc/how_to_contribute.rst
@@ -115,7 +115,7 @@ Upload the new version to PyPI
       - ``$ git fetch``
       - ``$ git checkout v0.6.3``
       - ``$ python setup.py sdist bdist_wheel``
-      - ``$ python setup.py bdist_wheel``
+      - ``$ python3 setup.py bdist_wheel``
   * Upload to testpypi_, and make sure all is well:
       - ``$ twine upload -r testpypi dist/katcp-0.6.3.tar.gz``
       - ``$ twine upload -r testpypi dist/katcp-0.6.3-py2-none-any.whl``

--- a/doc/how_to_contribute.rst
+++ b/doc/how_to_contribute.rst
@@ -115,13 +115,19 @@ Upload the new version to PyPI
       - ``$ git fetch``
       - ``$ git checkout v0.6.3``
       - ``$ python setup.py sdist bdist_wheel``
+      - ``$ python setup.py bdist_wheel``
   * Upload to testpypi_, and make sure all is well:
       - ``$ twine upload -r testpypi dist/katcp-0.6.3.tar.gz``
+      - ``$ twine upload -r testpypi dist/katcp-0.6.3-py2-none-any.whl``
+      - ``$ twine upload -r testpypi dist/katcp-0.6.3-py3-none-any.whl``
   * Test installation (in a virtualenv):
-      - ``$ pip install -i https://test.pypi.org/simple/ katcp``
+      - ``$ pip install katcp``
+      - ``$ pip install -U -i https://test.pypi.org/simple/ katcp``
+
   * Upload the source tarball and wheel to the real PyPI:
       - ``$ twine upload dist/katcp-0.6.3.tar.gz``
       - ``$ twine upload dist/katcp-0.6.3-py2-none-any.whl``
+      - ``$ twine upload dist/katcp-0.6.3-py3-none-any.whl``
 
 Fill in the release description on GitHub
   * Content must be the same as the details in the changelog.


### PR DESCRIPTION
Updating the `Upload the new version to PyPI` section on [readthedocs](https://katcp-python.readthedocs.io/en/v0.8.0/how_to_contribute.html#releasing-a-new-version)