### PR TITLE
Fixes issues with katcpreply repr in py3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+13 May 2021 (0.9.1)
+* Fix issues in KATCPReply `__repr__` in py3 (PR [#256](https://github.com/ska-sa/katcp-python/pull/256))
+
 29 January 2021 (0.9.0)
 * Add asyncio compatible ioloop to ioloop manager (PR [#254](https://github.com/ska-sa/katcp-python/pull/254))
 

--- a/doc/releasenotes.rst
+++ b/doc/releasenotes.rst
@@ -4,6 +4,10 @@
 Release Notes
 *************
 
+0.9.1
+=====
+* Fix issues in KATCPReply `__repr__` in py3
+
 0.9.0
 =====
 * Add asyncio compatible ioloop to ioloop manager.

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -22,6 +22,7 @@ from tornado.gen import Return, with_timeout
 
 from katcp import Message, Sensor
 from katcp.core import hashable_identity
+from katcp.compat import ensure_native_str
 
 logger = logging.getLogger(__name__)
 

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -1003,15 +1003,15 @@ class KATCPReply(_KATCPReplyTuple):
 
     def __repr__(self):
         """String representation for pretty-printing in IPython."""
-        return '\n'.join(
-            "%s%s %s" %
-            (
+        return "\n".join(
+            "%s%s %s"
+            % (
                 ensure_native_str(Message.TYPE_SYMBOLS[m.mtype]),
                 m.name,
-                ' '.join([ensure_native_str(arg)
-                          for arg in m.arguments])
-             )
-            for m in self.messages)
+                " ".join([ensure_native_str(arg) for arg in m.arguments]),
+            )
+            for m in self.messages
+        )
 
     def __str__(self):
         """String representation using KATCP wire format"""

--- a/katcp/resource.py
+++ b/katcp/resource.py
@@ -1005,7 +1005,12 @@ class KATCPReply(_KATCPReplyTuple):
         """String representation for pretty-printing in IPython."""
         return '\n'.join(
             "%s%s %s" %
-            (Message.TYPE_SYMBOLS[m.mtype], m.name, ' '.join(m.arguments))
+            (
+                ensure_native_str(Message.TYPE_SYMBOLS[m.mtype]),
+                m.name,
+                ' '.join([ensure_native_str(arg)
+                          for arg in m.arguments])
+             )
             for m in self.messages)
 
     def __str__(self):

--- a/katcp/test/test_resource.py
+++ b/katcp/test/test_resource.py
@@ -198,4 +198,4 @@ class test_KATCPReply(unittest.TestCase):
 
         reply = resource.KATCPReply(Message.reply('help', 'this', 'is a test', mid=123))
         self.assertEqual('!help this is a test', repr(reply))
-        self.assertEqual('!help[123] this is\_a\_test', str(reply)) # noqa: W605
+        self.assertEqual('!help[123] this is\_a\_test', str(reply))  # noqa: W605

--- a/katcp/test/test_resource.py
+++ b/katcp/test/test_resource.py
@@ -12,7 +12,7 @@ import mock
 import tornado.testing
 
 # Module under test
-from katcp import Sensor, resource
+from katcp import Message, Sensor, resource
 from katcp.testutils import TimewarpAsyncTestCase
 
 
@@ -159,6 +159,7 @@ class ConcreteKATCPRequest(resource.KATCPRequest):
     def issue_request(self, *args, **kwargs):
         pass
 
+
 class test_KATCPRequest(unittest.TestCase):
     def test_active(self):
         active = False
@@ -187,3 +188,14 @@ class test_KATCPRequest(unittest.TestCase):
         rv = DUT(*req_args, **req_kwargs)
         self.assertEqual(rv, DUT.issue_request.return_value)
         DUT.issue_request.assert_called_once_with(*req_args, **req_kwargs)
+
+
+class test_KATCPReply(unittest.TestCase):
+    def test_katcpreply(self):
+        reply = resource.KATCPReply(Message.reply('watchdog', 'ok', mid=123), [])
+        self.assertEqual('!watchdog ok', repr(reply))
+        self.assertEqual('!watchdog[123] ok', str(reply))
+
+        reply = resource.KATCPReply(Message.reply('help', 'this', 'is a test', mid=123), [])
+        self.assertEqual('!help this is a test', repr(reply))
+        self.assertEqual('!help[123] this is\_a\_test', str(reply))

--- a/katcp/test/test_resource.py
+++ b/katcp/test/test_resource.py
@@ -192,10 +192,10 @@ class test_KATCPRequest(unittest.TestCase):
 
 class test_KATCPReply(unittest.TestCase):
     def test_katcpreply(self):
-        reply = resource.KATCPReply(Message.reply('watchdog', 'ok', mid=123), [])
+        reply = resource.KATCPReply(Message.reply('watchdog', 'ok', mid=123))
         self.assertEqual('!watchdog ok', repr(reply))
         self.assertEqual('!watchdog[123] ok', str(reply))
 
-        reply = resource.KATCPReply(Message.reply('help', 'this', 'is a test', mid=123), [])
+        reply = resource.KATCPReply(Message.reply('help', 'this', 'is a test', mid=123))
         self.assertEqual('!help this is a test', repr(reply))
-        self.assertEqual('!help[123] this is\_a\_test', str(reply))
+        self.assertEqual('!help[123] this is\_a\_test', str(reply)) # noqa: W605

--- a/katcp/test/test_resource.py
+++ b/katcp/test/test_resource.py
@@ -192,10 +192,12 @@ class test_KATCPRequest(unittest.TestCase):
 
 class test_KATCPReply(unittest.TestCase):
     def test_katcpreply(self):
-        reply = resource.KATCPReply(Message.reply('watchdog', 'ok', mid=123))
+        reply = resource.KATCPReply(Message.reply('watchdog', 'ok', mid=123),
+                                    [])
         self.assertEqual('!watchdog ok', repr(reply))
         self.assertEqual('!watchdog[123] ok', str(reply))
 
-        reply = resource.KATCPReply(Message.reply('help', 'this', 'is a test', mid=123))
+        reply = resource.KATCPReply(Message.reply('help', 'this', 'is a test', mid=123),
+                                    [])
         self.assertEqual('!help this is a test', repr(reply))
         self.assertEqual('!help[123] this is\_a\_test', str(reply))  # noqa: W605


### PR DESCRIPTION
This PR addresses issues in `KATCPReply` and its `__repr__` method.

`katcp.Message`  arguments are returned as bytes in python 3 this causes issues in `KATCPReply` `__repr__` method using the `katcp.compat.ensure_native_str` fixes this.



