### PR TITLE
only ensure_native_str on text.

### DIFF
--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -420,7 +420,8 @@ class Timestamp(KatcpType):
         try:
             decoded = float(value)
         except:
-            value = ensure_native_str(value)
+            if is_text(value):
+                value = ensure_native_str(value)
             raise ValueError("Could not parse value '%s' as timestamp." %
                              value)
         if major < SEC_TS_KATCP_MAJOR:


### PR DESCRIPTION
Only use `ensure_native_str` on text.