### PR TITLE
Add Python 3.9 compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+21 October 2022 (0.9.3)
+* Address deprecation issues in Python 3.9 (PR [#263](https://github.com/ska-sa/katcp-python/pull/263))
+
 22 September 2022 (0.9.2)
 * consistent error message in py2 and py3 for error in Timestamp decode (PR [#258](https://github.com/ska-sa/katcp-python/pull/258))  
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,13 @@ pipeline {
                         sh 'tox -e py38'
                     }
                 }
+
+                stage ('py39') {
+                    steps {
+                        echo "Running nosetests on Python 3.9"
+                        sh 'tox -e py39'
+                    }
+                }
             }
 
             post {

--- a/doc/releasenotes.rst
+++ b/doc/releasenotes.rst
@@ -3,6 +3,10 @@
 *************
 Release Notes
 *************
+0.9.3
+=====
+* Make compatible in Python 3.9 by addressing deprecation issues.
+
 0.9.2
 =====
 * Consistent error message in py2 and py3 for error in Timestamp decode

--- a/katcp/kattypes.py
+++ b/katcp/kattypes.py
@@ -19,6 +19,10 @@ import struct
 
 from builtins import object
 from functools import partial, update_wrapper, wraps
+try:
+    from inspect import getfullargspec as get_args
+except ImportError:
+    from inspect import getargspec as get_args
 
 import future
 
@@ -711,7 +715,7 @@ def request(*types, **options):
 
         if all_argnames is None:
             # We must be on the inside. Introspect the parameter names.
-            all_argnames = inspect.getargspec(handler)[0]
+            all_argnames = get_args(handler)[0]
 
         params_start = 1        # Skip 'self' parameter
         if has_req:         # Skip 'req' parameter
@@ -890,7 +894,7 @@ def return_reply(*types, **options):
             # We are on the inside.
             # We must preserve the original function parameter names for the
             # request decorator
-            raw_handler._orig_argnames = inspect.getargspec(handler)[0]
+            raw_handler._orig_argnames = get_args(handler)[0]
 
         return raw_handler
 

--- a/katcp/resource_client.py
+++ b/katcp/resource_client.py
@@ -15,6 +15,12 @@ from builtins import object
 from concurrent.futures import Future
 from functools import partial
 
+try:
+    from collections.abc import Mapping  # noqa
+except ImportError:
+    from collections import Mapping  # noqa
+
+
 import tornado
 from future.utils import PY2
 
@@ -1601,7 +1607,7 @@ class ThreadSafeKATCPClientResourceRequestWrapper(ThreadSafeMethodAttrWrapper):
         return self._ioloop_wrapper.decorate_callable(self.__subject__.__call__)
 
 
-class MappingProxy(collections.Mapping):
+class MappingProxy(Mapping):
 
     def __init__(self, mapping, wrapper):
         self._mapping = mapping

--- a/katcp/server.py
+++ b/katcp/server.py
@@ -7,6 +7,8 @@
 """Servers for the KAT device control language."""
 
 from __future__ import absolute_import, division, print_function
+
+import future.utils
 from future import standard_library
 standard_library.install_aliases()  # noqa E402
 
@@ -871,8 +873,12 @@ class MessageHandlerThread(object):
             self._logger.info('Message handler thread stopped.')
 
     def start(self, timeout=None):
-        if self._thread and self._thread.isAlive():
-            raise RuntimeError('Cannot start since thread is already running')
+        if future.utils.PY2:
+            if self._thread and self._thread.isAlive():
+                raise RuntimeError('Cannot start since thread is already running')
+        else:
+            if self._thread and self._thread.is_alive():
+                raise RuntimeError('Cannot start since thread is already running')
         self._thread = threading.Thread(target=self.run, name=self.name)
         self._thread.start()
         if timeout:
@@ -905,7 +911,10 @@ class MessageHandlerThread(object):
         self._thread.join(timeout)
 
     def isAlive(self):
-        return self._thread and self._thread.isAlive()
+        if future.utils.PY2:
+            return self._thread and self._thread.isAlive()
+        else:
+            return self._thread and self._thread.is_alive()
 
     def running(self):
         """Whether the handler thread is running."""
@@ -1316,6 +1325,7 @@ class DeviceServerBase(with_metaclass(DeviceServerMetaclass, object)):
             Time in seconds to wait for server thread to start.
 
         """
+
         if self._handler_thread and self._handler_thread.isAlive():
             raise RuntimeError('Message handler thread already started')
         self._server.start(timeout)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27, 36, 37, 38},docs
+envlist = py{27, 36, 37, 38, 39},docs
 
 [testenv]
 passenv = test_flags

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{27, 36, 37, 38, 39},docs
 
 [testenv]
+setenv = COVERAGE_FILE=.coverage.{envname}
 passenv = test_flags
 commands =
     coverage run --source={env:test_flags} -m nose --xunit-file=nosetests_{envname}.xml


### PR DESCRIPTION
This PR addresses compatibility with Python 3.9 and its related deprecations see https://github.com/ska-sa/katcp-python/issues/262

changes
- get_args works in python 2 to 3.9
- Correct `Mapping` import 
-  add python 3.9 to tox and Jenkinsfile
- use `thread.is_alive()` in Python 3 
Please note 
I am looking into the env variable for coverage to correct multiple files being created correctly.

